### PR TITLE
Feature/#14 JWT Refresh Token 발급 및 만료 설정 추가

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/AuthController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.back.devc.domain.auth.dto.login.LoginRequest;
 import com.back.devc.domain.auth.dto.login.LoginResponse;
 import com.back.devc.domain.auth.dto.logout.LogoutRequest;
 import com.back.devc.domain.auth.dto.logout.LogoutResponse;
+import com.back.devc.domain.auth.dto.reissue.ReissueRequest;
+import com.back.devc.domain.auth.dto.reissue.ReissueResponse;
 import com.back.devc.domain.auth.dto.signup.SignUpRequest;
 import com.back.devc.domain.auth.dto.signup.SignUpResponse;
 import com.back.devc.domain.auth.service.AuthService;
@@ -23,6 +25,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<SuccessResponse<ReissueResponse>> reissue(@Valid @RequestBody ReissueRequest request) {
+        ReissueResponse response = authService.reissue(request);
+        SuccessCode successCode = SuccessCode.REISSUE_SUCCESS;
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
+    }
 
     @PostMapping("/logout")
     public ResponseEntity<SuccessResponse<LogoutResponse>> logout(@RequestBody(required = false) LogoutRequest request) {

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/login/LoginResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/login/LoginResponse.java
@@ -9,6 +9,7 @@ public record LoginResponse(
         String nickname,
         MemberRole role,
         MemberStatus status,
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/reissue/ReissueRequest.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/reissue/ReissueRequest.java
@@ -1,0 +1,9 @@
+package com.back.devc.domain.auth.dto.reissue;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueRequest(
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/reissue/ReissueResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/reissue/ReissueResponse.java
@@ -1,0 +1,7 @@
+package com.back.devc.domain.auth.dto.reissue;
+
+public record ReissueResponse(
+        String accessToken
+) {
+}
+

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
@@ -35,10 +35,10 @@ public class AuthService {
     @Transactional(readOnly = true)
     public LoginResponse login(LoginRequest request) {
         Member member = memberRepository.findByEmail(request.email())
-                .orElseThrow(() -> new ApiException(ErrorCode.INVALID_CREDENTIALS));
+                .orElseThrow(() -> new ApiException(ErrorCode.EMAIL_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.password(), member.getPasswordHash())) {
-            throw new ApiException(ErrorCode.INVALID_CREDENTIALS);
+            throw new ApiException(ErrorCode.PASSWORD_MISMATCH);
         }
 
         String accessToken = jwtProvider.createAccessToken(member);

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
@@ -4,6 +4,8 @@ import com.back.devc.domain.auth.dto.login.LoginRequest;
 import com.back.devc.domain.auth.dto.login.LoginResponse;
 import com.back.devc.domain.auth.dto.logout.LogoutRequest;
 import com.back.devc.domain.auth.dto.logout.LogoutResponse;
+import com.back.devc.domain.auth.dto.reissue.ReissueRequest;
+import com.back.devc.domain.auth.dto.reissue.ReissueResponse;
 import com.back.devc.domain.auth.dto.signup.SignUpRequest;
 import com.back.devc.domain.auth.dto.signup.SignUpResponse;
 import com.back.devc.domain.member.member.entity.Member;
@@ -11,6 +13,7 @@ import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.global.exception.ApiException;
 import com.back.devc.global.exception.ErrorCode;
 import com.back.devc.global.security.jwt.JwtProvider;
+import com.back.devc.global.security.jwt.TokenValidationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -39,6 +42,7 @@ public class AuthService {
         }
 
         String accessToken = jwtProvider.createAccessToken(member);
+        String refreshToken = jwtProvider.createRefreshToken(member);
 
         return new LoginResponse(
                 member.getUserId(),
@@ -46,8 +50,24 @@ public class AuthService {
                 member.getNickname(),
                 member.getRole(),
                 member.getStatus(),
-                accessToken
+                accessToken,
+                refreshToken
         );
+    }
+
+    @Transactional(readOnly = true)
+    public ReissueResponse reissue(ReissueRequest request) {
+        TokenValidationStatus tokenStatus = jwtProvider.validateRefreshTokenStatus(request.refreshToken());
+        if (!tokenStatus.isValid()) {
+            throw new ApiException(toTokenErrorCode(tokenStatus));
+        }
+
+        Long userId = jwtProvider.getUserId(request.refreshToken());
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+
+        String newAccessToken = jwtProvider.createAccessToken(member);
+        return new ReissueResponse(newAccessToken);
     }
 
     @Transactional
@@ -71,5 +91,14 @@ public class AuthService {
                 savedMember.getRole(),
                 savedMember.getStatus()
         );
+    }
+
+    private ErrorCode toTokenErrorCode(TokenValidationStatus tokenStatus) {
+        return switch (tokenStatus) {
+            case EXPIRED -> ErrorCode.EXPIRED_TOKEN;
+            case INVALID_TOKEN_TYPE -> ErrorCode.INVALID_TOKEN_TYPE;
+            case MISSING, MALFORMED, UNSUPPORTED, INVALID_SIGNATURE -> ErrorCode.INVALID_TOKEN;
+            case VALID -> ErrorCode.INVALID_TOKEN;
+        };
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
@@ -5,10 +5,15 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
+
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404_EMAIL_NOT_FOUND", "존재하지 않는 이메일입니다."),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH_401_PASSWORD_MISMATCH", "비밀번호가 일치하지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_CREDENTIALS", "이메일 또는 비밀번호가 일치하지 않습니다."),
+
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_EXPIRED_TOKEN", "만료된 토큰입니다."),
     INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_TOKEN_TYPE", "토큰 타입이 올바르지 않습니다."),
+
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404_NOT_FOUND", "회원을 찾을 수 없습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409_EMAIL", "이미 사용 중인 이메일입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409_NICKNAME", "이미 사용 중인 닉네임입니다.");

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
@@ -6,6 +6,9 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_CREDENTIALS", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_EXPIRED_TOKEN", "만료된 토큰입니다."),
+    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_TOKEN_TYPE", "토큰 타입이 올바르지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404_NOT_FOUND", "회원을 찾을 수 없습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409_EMAIL", "이미 사용 중인 이메일입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409_NICKNAME", "이미 사용 중인 닉네임입니다.");

--- a/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
     LOGIN_SUCCESS(HttpStatus.OK, "AUTH_200_LOGIN_SUCCESS", "로그인에 성공했습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "AUTH_200_LOGOUT_SUCCESS", "로그아웃이 완료되었습니다."),
+    REISSUE_SUCCESS(HttpStatus.OK, "AUTH_200_REISSUE_SUCCESS", "토큰 재발급에 성공했습니다."),
     ME_SUCCESS(HttpStatus.OK, "USER_200_ME_SUCCESS", "내 정보 조회에 성공했습니다."),
     SIGN_UP_SUCCESS(HttpStatus.CREATED, "AUTH_201_SIGNUP_SUCCESS", "회원가입이 완료되었습니다.");
 

--- a/back/DevC/src/main/java/com/back/devc/global/security/CustomAuthenticationEntryPoint.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.back.devc.global.security;
+
+import com.back.devc.global.exception.ApiException;
+import com.back.devc.global.exception.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    // Security 필터 단계에서 발생한 인증 예외를 전역 예외 처리기로 위임한다.
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    // 미인증 요청(401) 발생 시 공통 ErrorResponse 포맷으로 응답하도록 연결한다.
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        handlerExceptionResolver.resolveException(
+                request,
+                response,
+                null,
+                new ApiException(ErrorCode.UNAUTHORIZED)
+        );
+    }
+}

--- a/back/DevC/src/main/java/com/back/devc/global/security/SecurityConfig.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/SecurityConfig.java
@@ -1,8 +1,6 @@
 package com.back.devc.global.security;
 
-import com.back.devc.global.exception.ErrorCode;
 import com.back.devc.global.security.jwt.JwtAuthenticationFilter;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +12,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
-import java.time.LocalDateTime;
 
 @Configuration
 @EnableWebSecurity
@@ -24,7 +21,8 @@ public class SecurityConfig {
     SecurityFilterChain filterChain(
             HttpSecurity http,
             ObjectProvider<ClientRegistrationRepository> clientRegistrationRepositoryProvider,
-            JwtAuthenticationFilter jwtAuthenticationFilter
+            JwtAuthenticationFilter jwtAuthenticationFilter,
+            CustomAuthenticationEntryPoint customAuthenticationEntryPoint
     ) throws Exception {
         http
                 .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
@@ -39,23 +37,7 @@ public class SecurityConfig {
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling((exceptionHandling) -> exceptionHandling
-                        .authenticationEntryPoint((request, response, authException) -> {
-                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            response.setContentType("application/json");
-                            response.setCharacterEncoding("UTF-8");
-                            response.getWriter().write("""
-                                    {
-                                      "code":"%s",
-                                      "message":"%s",
-                                      "timestamp":"%s",
-                                      "validation":{}
-                                    }
-                                    """.formatted(
-                                    ErrorCode.UNAUTHORIZED.getCode(),
-                                    ErrorCode.UNAUTHORIZED.getMessage(),
-                                    LocalDateTime.now()
-                            ));
-                        }))
+                        .authenticationEntryPoint(customAuthenticationEntryPoint))
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(
                                 XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtAuthenticationFilter.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtAuthenticationFilter.java
@@ -30,20 +30,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-        // Authorization 헤더에서 Bearer 토큰 추출
         String token = resolveToken(request);
 
-        // 토큰이 있고 유효하며, 아직 인증 정보가 없을 때만 인증 객체를 생성한다.
-        if (token != null && jwtProvider.validateToken(token)
-                && SecurityContextHolder.getContext().getAuthentication() == null) {
-            // 토큰의 클레임에서 사용자 식별 정보 추출
+        if (token != null
+                && SecurityContextHolder.getContext().getAuthentication() == null
+                && jwtProvider.validateAccessTokenStatus(token) == TokenValidationStatus.VALID) {
             Long userId = jwtProvider.getUserId(token);
             String email = jwtProvider.getEmail(token);
             String role = jwtProvider.getRole(token);
 
-            // 인증 주체(principal) 생성
             JwtPrincipal principal = new JwtPrincipal(userId, email, role);
-            // Spring Security 인증 객체 생성 (권한은 ROLE_ 접두어 사용)
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(
                             principal,
@@ -51,15 +47,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                             List.of(new SimpleGrantedAuthority("ROLE_" + role))
                     );
 
-            // 현재 요청의 인증 컨텍스트에 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
-        // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
 
-    // Authorization: Bearer <token> 형식에서 JWT 문자열만 추출한다.
     private String resolveToken(HttpServletRequest request) {
         String authorization = request.getHeader(AUTHORIZATION_HEADER);
         if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
@@ -18,13 +18,16 @@ public class JwtProvider {
 
     private final SecretKey secretKey;
     private final long accessTokenExpirationSeconds;
+    private final long refreshTokenExpirationSeconds;
 
     public JwtProvider(
             @Value("${custom.jwt.secret-key}") String secretKey,
-            @Value("${custom.jwt.access-token-expiration-seconds}") long accessTokenExpirationSeconds
+            @Value("${custom.jwt.access-token-expiration-seconds}") long accessTokenExpirationSeconds,
+            @Value("${custom.jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
         this.accessTokenExpirationSeconds = accessTokenExpirationSeconds;
+        this.refreshTokenExpirationSeconds = refreshTokenExpirationSeconds;
     }
 
     public String createAccessToken(Member member) {
@@ -35,6 +38,19 @@ public class JwtProvider {
                 .subject(String.valueOf(member.getUserId()))
                 .claim("email", member.getEmail())
                 .claim("role", member.getRole().name())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiry))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Member member) {
+        Instant now = Instant.now();
+        Instant expiry = now.plusSeconds(refreshTokenExpirationSeconds);
+
+        return Jwts.builder()
+                .subject(String.valueOf(member.getUserId()))
+                .claim("tokenType", "REFRESH")
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(expiry))
                 .signWith(secretKey)

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
@@ -67,6 +67,15 @@ public class JwtProvider {
         }
     }
 
+    public boolean validateRefreshToken(String token) {
+        if (!validateToken(token)) {
+            return false;
+        }
+
+        String tokenType = parseClaims(token).get("tokenType", String.class);
+        return "REFRESH".equals(tokenType);
+    }
+
     // subject(userId) 클레임을 Long으로 변환해 반환한다.
     public Long getUserId(String token) {
         return Long.parseLong(parseClaims(token).getSubject());

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
@@ -40,6 +40,7 @@ public class JwtProvider {
 
         return Jwts.builder()
                 .subject(String.valueOf(member.getUserId()))
+                .claim("tokenType", "ACCESS")
                 .claim("email", member.getEmail())
                 .claim("role", member.getRole().name())
                 .issuedAt(Date.from(now))
@@ -68,6 +69,20 @@ public class JwtProvider {
 
     public boolean validateRefreshToken(String token) {
         return validateRefreshTokenStatus(token).isValid();
+    }
+
+    public TokenValidationStatus validateAccessTokenStatus(String token) {
+        TokenValidationStatus tokenStatus = validateTokenStatus(token);
+        if (!tokenStatus.isValid()) {
+            return tokenStatus;
+        }
+
+        String tokenType = parseClaims(token).get("tokenType", String.class);
+        if (!"ACCESS".equals(tokenType)) {
+            return TokenValidationStatus.INVALID_TOKEN_TYPE;
+        }
+
+        return TokenValidationStatus.VALID;
     }
 
     public TokenValidationStatus validateTokenStatus(String token) {

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtProvider.java
@@ -2,8 +2,12 @@ package com.back.devc.global.security.jwt;
 
 import com.back.devc.domain.member.member.entity.Member;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -59,21 +63,46 @@ public class JwtProvider {
 
     // 토큰 서명/만료/형식을 검증한다.
     public boolean validateToken(String token) {
-        try {
-            parseClaims(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
-        }
+        return validateTokenStatus(token).isValid();
     }
 
     public boolean validateRefreshToken(String token) {
-        if (!validateToken(token)) {
-            return false;
+        return validateRefreshTokenStatus(token).isValid();
+    }
+
+    public TokenValidationStatus validateTokenStatus(String token) {
+        if (token == null || token.isBlank()) {
+            return TokenValidationStatus.MISSING;
+        }
+
+        try {
+            parseClaims(token);
+            return TokenValidationStatus.VALID;
+        } catch (ExpiredJwtException e) {
+            return TokenValidationStatus.EXPIRED;
+        } catch (MalformedJwtException | IllegalArgumentException e) {
+            return TokenValidationStatus.MALFORMED;
+        } catch (UnsupportedJwtException e) {
+            return TokenValidationStatus.UNSUPPORTED;
+        } catch (SignatureException | SecurityException e) {
+            return TokenValidationStatus.INVALID_SIGNATURE;
+        } catch (JwtException e) {
+            return TokenValidationStatus.MALFORMED;
+        }
+    }
+
+    public TokenValidationStatus validateRefreshTokenStatus(String token) {
+        TokenValidationStatus tokenStatus = validateTokenStatus(token);
+        if (!tokenStatus.isValid()) {
+            return tokenStatus;
         }
 
         String tokenType = parseClaims(token).get("tokenType", String.class);
-        return "REFRESH".equals(tokenType);
+        if (!"REFRESH".equals(tokenType)) {
+            return TokenValidationStatus.INVALID_TOKEN_TYPE;
+        }
+
+        return TokenValidationStatus.VALID;
     }
 
     // subject(userId) 클레임을 Long으로 변환해 반환한다.

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/TokenValidationStatus.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/TokenValidationStatus.java
@@ -1,0 +1,15 @@
+package com.back.devc.global.security.jwt;
+
+public enum TokenValidationStatus {
+    VALID,
+    MISSING,
+    EXPIRED,
+    MALFORMED,
+    UNSUPPORTED,
+    INVALID_SIGNATURE,
+    INVALID_TOKEN_TYPE;
+
+    public boolean isValid() {
+        return this == VALID;
+    }
+}

--- a/back/DevC/src/main/resources/application-test.yml
+++ b/back/DevC/src/main/resources/application-test.yml
@@ -1,3 +1,7 @@
 spring:
   datasource:
     url: jdbc:h2:mem:db_dev;MODE=MySQL
+
+custom:
+  jwt:
+    refresh-token-expiration-seconds: 1209600

--- a/back/DevC/src/main/resources/application.yaml
+++ b/back/DevC/src/main/resources/application.yaml
@@ -39,5 +39,6 @@ logging:
 
 custom:
   jwt:
-    secret-key: "QkFzZv1faT1CmjVCThXvSf+/m+5jVqwaqPB5MqLpFPvpYwDj6kIQhnjrFn47eM4PLiL9bkRYwc2ILoy/9b2zhg==" # 임시 시크릿키
+    secret-key: "QkFzZv1faT1CmjVCThXvSf+/m+5jVqwaqPB5MqLpFPvpYwDj6kIQhnjrFn47eM4PLiL9bkRYwc2ILoy/9b2zhg=="
     access-token-expiration-seconds: 3600
+    refresh-token-expiration-seconds: 1209600

--- a/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthControllerTest.java
@@ -2,6 +2,7 @@ package com.back.devc.domain.auth.controller;
 
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
+import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -173,5 +174,92 @@ public class ApiAuthControllerTest {
                 .andExpect(jsonPath("$.data.nickname").value(nickname))
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    void refreshToken_으로_accessToken_재발급_성공() throws Exception {
+        String email = "reissue-user@test.com";
+        String rawPassword = "password123!";
+        String nickname = "reissueUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        memberRepository.save(member);
+
+        String loginResponse = mvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "email": "%s",
+                                          "password": "%s"
+                                        }
+                                        """.formatted(email, rawPassword))
+                )
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String refreshToken = JsonPath.read(loginResponse, "$.data.refreshToken");
+
+        ResultActions resultActions = mvc.perform(
+                        post("/api/auth/reissue")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "refreshToken": "%s"
+                                        }
+                                        """.formatted(refreshToken))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AuthController.class))
+                .andExpect(handler().methodName("reissue"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("AUTH_200_REISSUE_SUCCESS"))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+    }
+
+    @Test
+    void accessToken_으로_reissue_요청시_실패() throws Exception {
+        String email = "reissue-fail@test.com";
+        String rawPassword = "password123!";
+        String nickname = "reissueFailUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        memberRepository.save(member);
+
+        String loginResponse = mvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "email": "%s",
+                                          "password": "%s"
+                                        }
+                                        """.formatted(email, rawPassword))
+                )
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String accessToken = JsonPath.read(loginResponse, "$.data.accessToken");
+
+        ResultActions resultActions = mvc.perform(
+                        post("/api/auth/reissue")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "refreshToken": "%s"
+                                        }
+                                        """.formatted(accessToken))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AuthController.class))
+                .andExpect(handler().methodName("reissue"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_401_INVALID_TOKEN_TYPE"));
     }
 }

--- a/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthControllerTest.java
@@ -2,7 +2,6 @@ package com.back.devc.domain.auth.controller;
 
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
-import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,9 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -174,92 +171,5 @@ public class ApiAuthControllerTest {
                 .andExpect(jsonPath("$.data.nickname").value(nickname))
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andExpect(jsonPath("$.data.status").value("ACTIVE"));
-    }
-
-    @Test
-    void refreshToken_으로_accessToken_재발급_성공() throws Exception {
-        String email = "reissue-user@test.com";
-        String rawPassword = "password123!";
-        String nickname = "reissueUser";
-
-        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
-        memberRepository.save(member);
-
-        String loginResponse = mvc.perform(
-                        post("/api/auth/login")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
-                                        {
-                                          "email": "%s",
-                                          "password": "%s"
-                                        }
-                                        """.formatted(email, rawPassword))
-                )
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
-
-        String refreshToken = JsonPath.read(loginResponse, "$.data.refreshToken");
-
-        ResultActions resultActions = mvc.perform(
-                        post("/api/auth/reissue")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
-                                        {
-                                          "refreshToken": "%s"
-                                        }
-                                        """.formatted(refreshToken))
-                )
-                .andDo(print());
-
-        resultActions
-                .andExpect(handler().handlerType(AuthController.class))
-                .andExpect(handler().methodName("reissue"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("AUTH_200_REISSUE_SUCCESS"))
-                .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
-    }
-
-    @Test
-    void accessToken_으로_reissue_요청시_실패() throws Exception {
-        String email = "reissue-fail@test.com";
-        String rawPassword = "password123!";
-        String nickname = "reissueFailUser";
-
-        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
-        memberRepository.save(member);
-
-        String loginResponse = mvc.perform(
-                        post("/api/auth/login")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
-                                        {
-                                          "email": "%s",
-                                          "password": "%s"
-                                        }
-                                        """.formatted(email, rawPassword))
-                )
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
-
-        String accessToken = JsonPath.read(loginResponse, "$.data.accessToken");
-
-        ResultActions resultActions = mvc.perform(
-                        post("/api/auth/reissue")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
-                                        {
-                                          "refreshToken": "%s"
-                                        }
-                                        """.formatted(accessToken))
-                )
-                .andDo(print());
-
-        resultActions
-                .andExpect(handler().handlerType(AuthController.class))
-                .andExpect(handler().methodName("reissue"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.code").value("AUTH_401_INVALID_TOKEN_TYPE"));
     }
 }

--- a/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthReissueControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthReissueControllerTest.java
@@ -1,0 +1,124 @@
+package com.back.devc.domain.auth.controller;
+
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.repository.MemberRepository;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class ApiAuthReissueControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void refreshToken_으로_accessToken_재발급_성공() throws Exception {
+        String email = "reissue-user@test.com";
+        String rawPassword = "password123!";
+        String nickname = "reissueUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        memberRepository.save(member);
+
+        String loginResponse = mvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "email": "%s",
+                                          "password": "%s"
+                                        }
+                                        """.formatted(email, rawPassword))
+                )
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String refreshToken = JsonPath.read(loginResponse, "$.data.refreshToken");
+
+        ResultActions resultActions = mvc.perform(
+                        post("/api/auth/reissue")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "refreshToken": "%s"
+                                        }
+                                        """.formatted(refreshToken))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AuthController.class))
+                .andExpect(handler().methodName("reissue"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("AUTH_200_REISSUE_SUCCESS"))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+    }
+
+    @Test
+    void accessToken_으로_reissue_요청시_실패() throws Exception {
+        String email = "reissue-fail@test.com";
+        String rawPassword = "password123!";
+        String nickname = "reissueFailUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        memberRepository.save(member);
+
+        String loginResponse = mvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "email": "%s",
+                                          "password": "%s"
+                                        }
+                                        """.formatted(email, rawPassword))
+                )
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String accessToken = JsonPath.read(loginResponse, "$.data.accessToken");
+
+        ResultActions resultActions = mvc.perform(
+                        post("/api/auth/reissue")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "refreshToken": "%s"
+                                        }
+                                        """.formatted(accessToken))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AuthController.class))
+                .andExpect(handler().methodName("reissue"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_401_INVALID_TOKEN_TYPE"));
+    }
+}

--- a/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthReissueControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthReissueControllerTest.java
@@ -23,9 +23,7 @@ import java.util.Date;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -165,5 +163,72 @@ public class ApiAuthReissueControllerTest {
                 .andExpect(handler().methodName("reissue"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AUTH_401_EXPIRED_TOKEN"));
+    }
+
+    @Test
+    void 서명_위조된_리프레시_토큰_재발급_요청_실패() throws Exception {
+        String email = "reissue-tampered@test.com";
+        String rawPassword = "password123!";
+        String nickname = "reissueTamperedUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        memberRepository.save(member);
+
+        String loginResponse = mvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "email": "%s",
+                                          "password": "%s"
+                                        }
+                                        """.formatted(email, rawPassword))
+                )
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String refreshToken = JsonPath.read(loginResponse, "$.data.refreshToken");
+        String tamperedRefreshToken = refreshToken.substring(0, refreshToken.length() - 1)
+                + (refreshToken.endsWith("a") ? "b" : "a");
+
+        ResultActions resultActions = mvc.perform(
+                        post("/api/auth/reissue")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "refreshToken": "%s"
+                                        }
+                                        """.formatted(tamperedRefreshToken))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AuthController.class))
+                .andExpect(handler().methodName("reissue"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_401_INVALID_TOKEN"));
+    }
+
+    @Test
+    void 형식_깨진_리프레시_토큰_재발급_실패() throws Exception {
+        String malformedRefreshToken = "not-a-jwt-token";
+
+        ResultActions resultActions = mvc.perform(
+                        post("/api/auth/reissue")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "refreshToken": "%s"
+                                        }
+                                        """.formatted(malformedRefreshToken))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AuthController.class))
+                .andExpect(handler().methodName("reissue"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_401_INVALID_TOKEN"));
     }
 }

--- a/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthReissueControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/auth/controller/ApiAuthReissueControllerTest.java
@@ -3,8 +3,11 @@ package com.back.devc.domain.auth.controller;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.jayway.jsonpath.JsonPath;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -13,6 +16,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -35,8 +42,11 @@ public class ApiAuthReissueControllerTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Value("${custom.jwt.secret-key}")
+    private String jwtSecretKey;
+
     @Test
-    void refreshToken_으로_accessToken_재발급_성공() throws Exception {
+    void 리프레시토큰으로_재발급_성공() throws Exception {
         String email = "reissue-user@test.com";
         String rawPassword = "password123!";
         String nickname = "reissueUser";
@@ -80,7 +90,7 @@ public class ApiAuthReissueControllerTest {
     }
 
     @Test
-    void accessToken_으로_reissue_요청시_실패() throws Exception {
+    void 액세스토큰으로_재발급요청_실패() throws Exception {
         String email = "reissue-fail@test.com";
         String rawPassword = "password123!";
         String nickname = "reissueFailUser";
@@ -120,5 +130,40 @@ public class ApiAuthReissueControllerTest {
                 .andExpect(handler().methodName("reissue"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AUTH_401_INVALID_TOKEN_TYPE"));
+    }
+
+    @Test
+    void 만료된_리프레시토큰으로_재발급요청_실패() throws Exception {
+        String email = "reissue-expired@test.com";
+        String rawPassword = "password123!";
+        String nickname = "reissueExpiredUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        Member savedMember = memberRepository.save(member);
+
+        String expiredRefreshToken = Jwts.builder()
+                .subject(String.valueOf(savedMember.getUserId()))
+                .claim("tokenType", "REFRESH")
+                .issuedAt(Date.from(Instant.now().minusSeconds(120)))
+                .expiration(Date.from(Instant.now().minusSeconds(60)))
+                .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+
+        ResultActions resultActions = mvc.perform(
+                        post("/api/auth/reissue")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "refreshToken": "%s"
+                                        }
+                                        """.formatted(expiredRefreshToken))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AuthController.class))
+                .andExpect(handler().methodName("reissue"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_401_EXPIRED_TOKEN"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #14

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] Refresh Token 생성/검증 로직 추가
- [x] 토큰 검증 예외 케이스(만료/서명 오류/형식 오류) 처리 기준 정리
- [x] Refresh Token 동작 검증 테스트 추가

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
- yaml파일 refresh 토큰 추가
- SecurityConfig : 세션 OFF + JWT 필터 적용 + 공개/인증 API 분리 + 401 응답 공통 포맷 통일 + OAuth2 조건부 활성화

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?