### PR TITLE
Feature/#19 비활성 로그인 차단 및 JWT 필터 DB 사용자 검증 추가

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
@@ -71,6 +71,10 @@ public class AuthService {
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
 
+        if (member.getStatus() == MemberStatus.BLACKLISTED) {
+            throw new ApiException(ErrorCode.MEMBER_BLACKLISTED);
+        }
+
         String newAccessToken = jwtProvider.createAccessToken(member);
         return new ReissueResponse(newAccessToken);
     }

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import com.back.devc.domain.auth.dto.reissue.ReissueResponse;
 import com.back.devc.domain.auth.dto.signup.SignUpRequest;
 import com.back.devc.domain.auth.dto.signup.SignUpResponse;
 import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.entity.MemberStatus;
 import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.global.exception.ApiException;
 import com.back.devc.global.exception.ErrorCode;
@@ -36,6 +37,10 @@ public class AuthService {
     public LoginResponse login(LoginRequest request) {
         Member member = memberRepository.findByEmail(request.email())
                 .orElseThrow(() -> new ApiException(ErrorCode.EMAIL_NOT_FOUND));
+
+        if (member.getStatus() == MemberStatus.BLACKLISTED) {
+            throw new ApiException(ErrorCode.MEMBER_BLACKLISTED);
+        }
 
         if (!passwordEncoder.matches(request.password(), member.getPasswordHash())) {
             throw new ApiException(ErrorCode.PASSWORD_MISMATCH);

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
 
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404_EMAIL_NOT_FOUND", "존재하지 않는 이메일입니다."),
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH_401_PASSWORD_MISMATCH", "비밀번호가 일치하지 않습니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_CREDENTIALS", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    MEMBER_BLACKLISTED(HttpStatus.FORBIDDEN, "AUTH_403_MEMBER_BLACKLISTED", "이용할 수 없는 계정입니다.(사유 : 경고 누적으로 인한 정지)"),
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_EXPIRED_TOKEN", "만료된 토큰입니다."),

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtAuthenticationFilter.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package com.back.devc.global.security.jwt;
 
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.entity.MemberStatus;
+import com.back.devc.domain.member.member.repository.MemberRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,6 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
 
     // 모든 요청마다 1회 실행되며, JWT가 유효하면 인증 정보를 SecurityContext에 저장한다.
     @Override
@@ -36,8 +40,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 && SecurityContextHolder.getContext().getAuthentication() == null
                 && jwtProvider.validateAccessTokenStatus(token) == TokenValidationStatus.VALID) {
             Long userId = jwtProvider.getUserId(token);
-            String email = jwtProvider.getEmail(token);
-            String role = jwtProvider.getRole(token);
+
+            Member member = memberRepository.findById(userId).orElse(null);
+            if (member == null || member.getStatus() == MemberStatus.BLACKLISTED) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            String email = member.getEmail();
+            String role = member.getRole().name();
 
             JwtPrincipal principal = new JwtPrincipal(userId, email, role);
             UsernamePasswordAuthenticationToken authentication =

--- a/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtAuthenticationFilter.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/jwt/JwtAuthenticationFilter.java
@@ -34,15 +34,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
+        // Authorization 헤더에서 Bearer 토큰 추출
         String token = resolveToken(request);
 
+        // 이미 인증된 요청이 아니고, Access Token이 유효한 경우에만 인증 시도
         if (token != null
                 && SecurityContextHolder.getContext().getAuthentication() == null
                 && jwtProvider.validateAccessTokenStatus(token) == TokenValidationStatus.VALID) {
             Long userId = jwtProvider.getUserId(token);
 
+            // 토큰 클레임만 신뢰하지 않고 DB에서 사용자 현재 상태를 다시 확인
             Member member = memberRepository.findById(userId).orElse(null);
-            if (member == null || member.getStatus() == MemberStatus.BLACKLISTED) {
+            if (!isAuthenticatableMember(member)) {
+                // 미인증 상태로 남겨두면, 보호된 API 접근 시 Security가 401로 처리한다.
+                SecurityContextHolder.clearContext();
                 filterChain.doFilter(request, response);
                 return;
             }
@@ -62,6 +67,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    // 현재 정책: 사용자 존재 + BLACKLISTED 아님 => 인증 허용
+    private boolean isAuthenticatableMember(Member member) {
+        return member != null && member.getStatus() != MemberStatus.BLACKLISTED;
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/back/DevC/src/test/java/com/back/devc/domain/member/member/controller/UserMeAuthorizationTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/member/member/controller/UserMeAuthorizationTest.java
@@ -1,0 +1,138 @@
+package com.back.devc.domain.member.member.controller;
+
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.entity.MemberStatus;
+import com.back.devc.domain.member.member.repository.MemberRepository;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+class UserMeAuthorizationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("내 정보 조회 - 정상 사용자면 200 응답")
+    void me_AuthorizedUser_Success() throws Exception {
+        String email = "me-ok@test.com";
+        String rawPassword = "password123!";
+        String nickname = "meOkUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        memberRepository.save(member);
+
+        String accessToken = loginAndGetAccessToken(email, rawPassword);
+
+        mvc.perform(
+                        get("/api/users/me")
+                                .header("Authorization", "Bearer " + accessToken)
+                )
+                .andDo(print())
+                .andExpect(handler().handlerType(UserController.class))
+                .andExpect(handler().methodName("me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("USER_200_ME_SUCCESS"))
+                .andExpect(jsonPath("$.data.email").value(email))
+                .andExpect(jsonPath("$.data.nickname").value(nickname))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 - 블랙리스트 사용자면 401 응답")
+    void me_BlacklistedUser_Unauthorized() throws Exception {
+        String email = "me-blacklisted@test.com";
+        String rawPassword = "password123!";
+        String nickname = "meBlockedUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        Member savedMember = memberRepository.save(member);
+        String accessToken = loginAndGetAccessToken(email, rawPassword);
+
+        entityManager.createQuery("update Member m set m.status = :status where m.userId = :userId")
+                .setParameter("status", MemberStatus.BLACKLISTED)
+                .setParameter("userId", savedMember.getUserId())
+                .executeUpdate();
+        entityManager.flush();
+        entityManager.clear();
+
+        mvc.perform(
+                        get("/api/users/me")
+                                .header("Authorization", "Bearer " + accessToken)
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("COMMON_401"));
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 - 삭제된 사용자면 401 응답")
+    void me_DeletedUser_Unauthorized() throws Exception {
+        String email = "me-deleted@test.com";
+        String rawPassword = "password123!";
+        String nickname = "meDeletedUser";
+
+        Member member = Member.createLocalMember(email, passwordEncoder.encode(rawPassword), nickname);
+        Member savedMember = memberRepository.save(member);
+        String accessToken = loginAndGetAccessToken(email, rawPassword);
+
+        memberRepository.deleteById(savedMember.getUserId());
+        memberRepository.flush();
+
+        mvc.perform(
+                        get("/api/users/me")
+                                .header("Authorization", "Bearer " + accessToken)
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("COMMON_401"));
+    }
+
+    private String loginAndGetAccessToken(String email, String rawPassword) throws Exception {
+        String responseBody = mvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "email": "%s",
+                                          "password": "%s"
+                                        }
+                                        """.formatted(email, rawPassword))
+                )
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return JsonPath.read(responseBody, "$.data.accessToken");
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #19

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 로그인 시 사용자 상태 검사 추가 (`BLACKLISTED` 로그인 비허용)
- [x] JWT 필터에서 토큰 클레임만 신뢰하지 않고 DB 사용자 조회 후 인증 객체 세팅
- [x] 존재하지 않거나 비활성(`BLACKLISTED`) 사용자면 SecurityContext 미세팅 + 401 처리 흐름 정리
- [x] "내 정보 조회" 보호 API 검증 테스트 추가 (정상/비활성/삭제 사용자)
- [x] 로그인 실패 응답 통일(계정 존재 여부 노출 방지)

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?