### PR TITLE
feat: 게시글 댓글 기본 연동 및 대댓글 계층 구조 응답 적용(#25, #27)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -20,4 +22,30 @@ public class CommentResponse {
     private boolean isDeleted;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private List<CommentResponse> replies;
+
+    public static CommentResponse of(
+            Long commentId,
+            Long postId,
+            Long userId,
+            String nickname,
+            Long parentCommentId,
+            String content,
+            boolean isDeleted,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return CommentResponse.builder()
+                .commentId(commentId)
+                .postId(postId)
+                .userId(userId)
+                .nickname(nickname)
+                .parentCommentId(parentCommentId)
+                .content(content)
+                .isDeleted(isDeleted)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .replies(new ArrayList<>())
+                .build();
+    }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
@@ -45,6 +45,10 @@ public class CommentServiceImpl implements CommentService {
         Comment parentComment = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다. id=" + parentCommentId));
 
+        if (parentComment.isDeleted()) {
+            throw new IllegalStateException("삭제된 댓글에는 대댓글을 작성할 수 없습니다. id=" + parentCommentId);
+        }
+
         Comment reply = Comment.create(parentComment.getPostId(), loginUserId, parentCommentId, request.getContent());
         Comment savedReply = commentRepository.save(reply);
 

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
@@ -8,6 +8,7 @@ import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.dto.CommentUpdateRequest;
 import com.back.devc.domain.post.comment.entity.Comment;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
+import com.back.devc.domain.post.post.repository.PostRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,11 +22,15 @@ import java.util.List;
 public class CommentServiceImpl implements CommentService {
 
     private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
     private final NotificationService notificationService;
 
     @Override
     @Transactional
     public CommentResponse createComment(Long postId, Long loginUserId, CommentCreateRequest request) {
+        postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId));
+
         Comment comment = Comment.create(postId, loginUserId, null, request.getContent());
         Comment savedComment = commentRepository.save(comment);
 
@@ -85,6 +90,9 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public CommentListResponse getComments(Long postId) {
+        postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId));
+
         List<CommentResponse> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId)
                 .stream()
                 .map(this::toResponse)

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
@@ -93,16 +93,34 @@ public class CommentServiceImpl implements CommentService {
         postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId));
 
-        List<CommentResponse> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId)
+        List<CommentResponse> allComments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId)
                 .stream()
                 .map(this::toResponse)
                 .toList();
 
-        return new CommentListResponse(comments);
+        List<CommentResponse> parentComments = new java.util.ArrayList<>();
+        java.util.Map<Long, CommentResponse> commentMap = new java.util.LinkedHashMap<>();
+
+        for (CommentResponse commentResponse : allComments) {
+            commentMap.put(commentResponse.getCommentId(), commentResponse);
+        }
+
+        for (CommentResponse commentResponse : allComments) {
+            if (commentResponse.getParentCommentId() == null) {
+                parentComments.add(commentResponse);
+            } else {
+                CommentResponse parent = commentMap.get(commentResponse.getParentCommentId());
+                if (parent != null) {
+                    parent.getReplies().add(commentResponse);
+                }
+            }
+        }
+
+        return new CommentListResponse(parentComments);
     }
 
     private CommentResponse toResponse(Comment comment) {
-        return new CommentResponse(
+        return CommentResponse.of(
                 comment.getId(),
                 comment.getPostId(),
                 comment.getUserId(),

--- a/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/controller/NotificationControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/controller/NotificationControllerTest.java
@@ -4,6 +4,8 @@ import com.back.devc.domain.interaction.notification.dto.NotificationListRespons
 import com.back.devc.domain.interaction.notification.dto.NotificationResponse;
 import com.back.devc.domain.interaction.notification.service.NotificationService;
 import com.back.devc.global.security.jwt.JwtProvider;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(NotificationController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class NotificationControllerTest {
@@ -30,6 +33,9 @@ class NotificationControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
     @DisplayName("내 알림 목록 조회 API 호출 성공")

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -22,6 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(CommentAttachmentController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class CommentAttachmentControllerTest {
@@ -34,6 +37,9 @@ class CommentAttachmentControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
     @DisplayName("댓글 첨부 업로드 API 호출 성공")

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
@@ -5,6 +5,8 @@ import com.back.devc.domain.post.comment.dto.CommentListResponse;
 import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.service.CommentService;
 import com.back.devc.global.security.jwt.JwtProvider;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -23,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(CommentController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class CommentControllerTest {
@@ -35,6 +38,9 @@ class CommentControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
     @DisplayName("댓글 작성 API 호출 성공")


### PR DESCRIPTION
## 📌 관련 이슈
Closes #25 
Closes #27 

## 🛠️ 작업 내용
### 1. 게시글 존재 검증 기반 댓글 작성/조회 연동
- `CommentServiceImpl`에 `PostRepository`를 주입했습니다.
- 댓글 작성(`createComment`) 전에 게시글 존재 여부를 검증하도록 수정했습니다.
- 댓글 목록 조회(`getComments`) 전에 게시글 존재 여부를 검증하도록 수정했습니다.
- 존재하지 않는 게시글에 대해서는 `EntityNotFoundException`이 발생하도록 처리했습니다.

### 2. 게시글 댓글 목록 대댓글 계층 구조 응답 적용
- `CommentResponse`에 `replies` 필드를 추가했습니다.
- 댓글 응답 생성 시 `replies`가 기본적으로 빈 리스트로 초기화되도록 구성했습니다.
- `CommentServiceImpl#getComments()`에서 댓글 전체 목록을 조회한 뒤,
  부모 댓글과 대댓글을 구분해서 계층 구조로 응답하도록 수정했습니다.
- `parentCommentId == null` 댓글은 최상위 댓글로,
  `parentCommentId != null` 댓글은 부모 댓글의 `replies`에 포함되도록 처리했습니다.

## 🎯 리뷰 포인트
- 댓글 작성/조회 시 게시글 존재 검증 로직이 적절한지 확인 부탁드립니다.
- 댓글 목록 응답이 프론트에서 사용하기 적절한 계층 구조인지 확인 부탁드립니다.
- 현재 작업 범위와 직접 관련 없는 인증 영역 테스트(`ApiAuthReissueControllerTest`) 실패는 별도 이슈로 분리해두는 방향으로 보고 있습니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="718" height="584" alt="image" src="https://github.com/user-attachments/assets/e74b6562-5599-420f-a687-51716fe61a98" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?