### PR TITLE
feat: 댓글 기능 안정화 및 리팩토링(#30, #32, #33, #40, #41, #43)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
@@ -26,16 +26,13 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     @Transactional
     public void createCommentNotification(Long postId, Long actorUserId, Long commentId) {
-        Long postOwnerId = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId))
-                .getMember()
-                .getUserId();
+        Long postOwnerId = findPostOwnerId(postId);
 
         if (postOwnerId.equals(actorUserId)) {
             return;
         }
 
-        Notification notification = Notification.create(
+        saveNotification(
                 postOwnerId,
                 actorUserId,
                 postId,
@@ -43,15 +40,12 @@ public class NotificationServiceImpl implements NotificationService {
                 "COMMENT",
                 actorUserId + "번 사용자가 게시글에 댓글을 남겼습니다."
         );
-
-        notificationRepository.save(notification);
     }
 
     @Override
     @Transactional
     public void createReplyNotification(Long parentCommentId, Long actorUserId, Long replyCommentId) {
-        Comment parentComment = commentRepository.findById(parentCommentId)
-                .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다. id=" + parentCommentId));
+        Comment parentComment = findCommentOrThrow(parentCommentId, "부모 댓글을 찾을 수 없습니다. id=" + parentCommentId);
 
         if (parentComment.isDeleted()) {
             return;
@@ -63,7 +57,7 @@ public class NotificationServiceImpl implements NotificationService {
             return;
         }
 
-        Notification notification = Notification.create(
+        saveNotification(
                 receiverUserId,
                 actorUserId,
                 parentComment.getPostId(),
@@ -71,8 +65,6 @@ public class NotificationServiceImpl implements NotificationService {
                 "REPLY",
                 actorUserId + "번 사용자가 회원님의 댓글에 답글을 남겼습니다."
         );
-
-        notificationRepository.save(notification);
     }
 
     @Override
@@ -97,6 +89,38 @@ public class NotificationServiceImpl implements NotificationService {
 
         notification.markAsRead();
         return toResponse(notification);
+    }
+
+    private Long findPostOwnerId(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId))
+                .getMember()
+                .getUserId();
+    }
+
+    private Comment findCommentOrThrow(Long commentId, String message) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException(message));
+    }
+
+    private void saveNotification(
+            Long receiverUserId,
+            Long actorUserId,
+            Long postId,
+            Long commentId,
+            String type,
+            String message
+    ) {
+        Notification notification = Notification.create(
+                receiverUserId,
+                actorUserId,
+                postId,
+                commentId,
+                type,
+                message
+        );
+
+        notificationRepository.save(notification);
     }
 
     private NotificationResponse toResponse(Notification notification) {

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
@@ -6,6 +6,7 @@ import com.back.devc.domain.interaction.notification.entity.Notification;
 import com.back.devc.domain.interaction.notification.repository.NotificationRepository;
 import com.back.devc.domain.post.comment.entity.Comment;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
+import com.back.devc.domain.post.post.repository.PostRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,11 +21,15 @@ public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
 
     @Override
     @Transactional
     public void createCommentNotification(Long postId, Long actorUserId, Long commentId) {
-        Long postOwnerId = 1L;
+        Long postOwnerId = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId))
+                .getMember()
+                .getUserId();
 
         if (postOwnerId.equals(actorUserId)) {
             return;
@@ -47,6 +52,10 @@ public class NotificationServiceImpl implements NotificationService {
     public void createReplyNotification(Long parentCommentId, Long actorUserId, Long replyCommentId) {
         Comment parentComment = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다. id=" + parentCommentId));
+
+        if (parentComment.isDeleted()) {
+            return;
+        }
 
         Long receiverUserId = parentComment.getUserId();
 

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
@@ -6,14 +6,12 @@ import com.back.devc.domain.post.comment.dto.CommentListResponse;
 import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.dto.CommentUpdateRequest;
 import com.back.devc.domain.post.comment.service.CommentService;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
+
 
 @RestController
 @RequestMapping("/api")
@@ -60,17 +58,5 @@ public class CommentController {
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentListResponse> getComments(@PathVariable Long postId) {
         return ResponseEntity.ok(commentService.getComments(postId));
-    }
-
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleEntityNotFound(EntityNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(Map.of("message", e.getMessage()));
-    }
-
-    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
-    public ResponseEntity<Map<String, String>> handleBadRequest(RuntimeException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", e.getMessage()));
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
@@ -23,7 +23,7 @@ public class CommentController {
             @PathVariable Long postId,
             @RequestBody @Valid CommentCreateRequest request
     ) {
-        Long loginUserId = 1L;
+        Long loginUserId = 2L;
         return ResponseEntity.ok(commentService.createComment(postId, loginUserId, request));
     }
 
@@ -41,7 +41,7 @@ public class CommentController {
             @PathVariable Long commentId,
             @RequestBody @Valid CommentUpdateRequest request
     ) {
-        Long loginUserId = 1L;
+        Long loginUserId = 2L;
         return ResponseEntity.ok(commentService.updateComment(commentId, loginUserId, request));
     }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
@@ -6,10 +6,14 @@ import com.back.devc.domain.post.comment.dto.CommentListResponse;
 import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.dto.CommentUpdateRequest;
 import com.back.devc.domain.post.comment.service.CommentService;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -56,5 +60,17 @@ public class CommentController {
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentListResponse> getComments(@PathVariable Long postId) {
         return ResponseEntity.ok(commentService.getComments(postId));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleEntityNotFound(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("message", e.getMessage()));
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+    public ResponseEntity<Map<String, String>> handleBadRequest(RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", e.getMessage()));
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
@@ -25,8 +25,7 @@ public class CommentController {
             @PathVariable Long postId,
             @RequestBody @Valid CommentCreateRequest request
     ) {
-        Long loginUserId = 2L;
-        return ResponseEntity.ok(commentService.createComment(postId, loginUserId, request));
+        return ResponseEntity.ok(commentService.createComment(postId, getLoginUserId(), request));
     }
 
     @PostMapping("/comments/{commentId}/replies")
@@ -34,8 +33,7 @@ public class CommentController {
             @PathVariable Long commentId,
             @RequestBody @Valid CommentCreateRequest request
     ) {
-        Long loginUserId = 2L;
-        return ResponseEntity.ok(commentService.createReply(commentId, loginUserId, request));
+        return ResponseEntity.ok(commentService.createReply(commentId, getLoginUserId(), request));
     }
 
     @PatchMapping("/comments/{commentId}")
@@ -43,20 +41,22 @@ public class CommentController {
             @PathVariable Long commentId,
             @RequestBody @Valid CommentUpdateRequest request
     ) {
-        Long loginUserId = 2L;
-        return ResponseEntity.ok(commentService.updateComment(commentId, loginUserId, request));
+        return ResponseEntity.ok(commentService.updateComment(commentId, getLoginUserId(), request));
     }
 
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<CommentDeleteResponse> deleteComment(
             @PathVariable Long commentId
     ) {
-        Long loginUserId = 1L;
-        return ResponseEntity.ok(commentService.deleteComment(commentId, loginUserId));
+        return ResponseEntity.ok(commentService.deleteComment(commentId, getLoginUserId()));
     }
 
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentListResponse> getComments(@PathVariable Long postId) {
         return ResponseEntity.ok(commentService.getComments(postId));
+    }
+
+    private Long getLoginUserId() {
+        return 2L;
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
@@ -14,7 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -42,12 +45,8 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @Transactional
     public CommentResponse createReply(Long parentCommentId, Long loginUserId, CommentCreateRequest request) {
-        Comment parentComment = commentRepository.findById(parentCommentId)
-                .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다. id=" + parentCommentId));
-
-        if (parentComment.isDeleted()) {
-            throw new IllegalStateException("삭제된 댓글에는 대댓글을 작성할 수 없습니다. id=" + parentCommentId);
-        }
+        Comment parentComment = findCommentOrThrow(parentCommentId, "부모 댓글을 찾을 수 없습니다. id=" + parentCommentId);
+        validateReplyWritable(parentComment, parentCommentId);
 
         Comment reply = Comment.create(parentComment.getPostId(), loginUserId, parentCommentId, request.getContent());
         Comment savedReply = commentRepository.save(reply);
@@ -60,16 +59,9 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @Transactional
     public CommentResponse updateComment(Long commentId, Long loginUserId, CommentUpdateRequest request) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
-
-        if (!comment.isOwner(loginUserId)) {
-            throw new IllegalArgumentException("본인의 댓글만 수정할 수 있습니다.");
-        }
-
-        if (comment.isDeleted()) {
-            throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다.");
-        }
+        Comment comment = findCommentOrThrow(commentId, "댓글을 찾을 수 없습니다. id=" + commentId);
+        validateCommentOwner(comment, loginUserId, "본인의 댓글만 수정할 수 있습니다.");
+        validateCommentNotDeleted(comment, "삭제된 댓글은 수정할 수 없습니다.");
 
         comment.updateContent(request.getContent());
         return toResponse(comment);
@@ -78,12 +70,8 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @Transactional
     public CommentDeleteResponse deleteComment(Long commentId, Long loginUserId) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
-
-        if (!comment.isOwner(loginUserId)) {
-            throw new IllegalArgumentException("본인의 댓글만 삭제할 수 있습니다.");
-        }
+        Comment comment = findCommentOrThrow(commentId, "댓글을 찾을 수 없습니다. id=" + commentId);
+        validateCommentOwner(comment, loginUserId, "본인의 댓글만 삭제할 수 있습니다.");
 
         if (!comment.isDeleted()) {
             comment.softDelete();
@@ -94,16 +82,29 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public CommentListResponse getComments(Long postId) {
+        validatePostExists(postId);
+
+        List<CommentResponse> allComments = loadComments(postId);
+        List<CommentResponse> parentComments = buildCommentHierarchy(allComments);
+
+        return new CommentListResponse(parentComments);
+    }
+
+    private void validatePostExists(Long postId) {
         postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId));
+    }
 
-        List<CommentResponse> allComments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId)
+    private List<CommentResponse> loadComments(Long postId) {
+        return commentRepository.findByPostIdOrderByCreatedAtAsc(postId)
                 .stream()
                 .map(this::toResponse)
                 .toList();
+    }
 
-        List<CommentResponse> parentComments = new java.util.ArrayList<>();
-        java.util.Map<Long, CommentResponse> commentMap = new java.util.LinkedHashMap<>();
+    private List<CommentResponse> buildCommentHierarchy(List<CommentResponse> allComments) {
+        List<CommentResponse> parentComments = new ArrayList<>();
+        Map<Long, CommentResponse> commentMap = new LinkedHashMap<>();
 
         for (CommentResponse commentResponse : allComments) {
             commentMap.put(commentResponse.getCommentId(), commentResponse);
@@ -120,7 +121,30 @@ public class CommentServiceImpl implements CommentService {
             }
         }
 
-        return new CommentListResponse(parentComments);
+        return parentComments;
+    }
+
+    private Comment findCommentOrThrow(Long commentId, String message) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException(message));
+    }
+
+    private void validateReplyWritable(Comment parentComment, Long parentCommentId) {
+        if (parentComment.isDeleted()) {
+            throw new IllegalStateException("삭제된 댓글에는 대댓글을 작성할 수 없습니다. id=" + parentCommentId);
+        }
+    }
+
+    private void validateCommentOwner(Comment comment, Long loginUserId, String message) {
+        if (!comment.isOwner(loginUserId)) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    private void validateCommentNotDeleted(Comment comment, String message) {
+        if (comment.isDeleted()) {
+            throw new IllegalStateException(message);
+        }
     }
 
     private CommentResponse toResponse(Comment comment) {

--- a/back/DevC/src/main/java/com/back/devc/global/exception/GlobalExceptionHandler.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/GlobalExceptionHandler.java
@@ -48,4 +48,16 @@ public class GlobalExceptionHandler {
                 .status(ErrorCode.UNAUTHORIZED.getStatus())
                 .body(ErrorResponse.of(ErrorCode.UNAUTHORIZED));
     }
+    // 엔티티 조회 실패 시 404로 응답
+    @ExceptionHandler(jakarta.persistence.EntityNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleEntityNotFound(jakarta.persistence.EntityNotFoundException e) {
+        return ResponseEntity.status(404)
+                .body(Map.of("message", e.getMessage()));
+    }
+    // 잘못된 요청 상태는 400으로 응답
+    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+    public ResponseEntity<Map<String, String>> handleBadRequest(RuntimeException e) {
+        return ResponseEntity.badRequest()
+                .body(Map.of("message", e.getMessage()));
+    }
 }

--- a/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/controller/NotificationControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/controller/NotificationControllerTest.java
@@ -4,6 +4,7 @@ import com.back.devc.domain.interaction.notification.dto.NotificationListRespons
 import com.back.devc.domain.interaction.notification.dto.NotificationResponse;
 import com.back.devc.domain.interaction.notification.service.NotificationService;
 import com.back.devc.global.security.jwt.JwtProvider;
+import com.back.devc.domain.member.member.repository.MemberRepository;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,9 @@ class NotificationControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
@@ -4,6 +4,7 @@ import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentDeleteR
 import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentListResponse;
 import com.back.devc.domain.post.comment.attachment.service.CommentAttachmentService;
 import com.back.devc.global.security.jwt.JwtProvider;
+import com.back.devc.domain.member.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,9 @@ class CommentAttachmentControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
@@ -5,6 +5,7 @@ import com.back.devc.domain.post.comment.dto.CommentListResponse;
 import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.service.CommentService;
 import com.back.devc.global.security.jwt.JwtProvider;
+import com.back.devc.domain.member.member.repository.MemberRepository;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +41,9 @@ class CommentControllerTest {
     private JwtProvider jwtProvider;
 
     @MockitoBean
+    private MemberRepository memberRepository;
+
+    @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
@@ -49,7 +53,7 @@ class CommentControllerTest {
 
         given(commentService.createComment(
                 ArgumentMatchers.eq(1L),
-                ArgumentMatchers.eq(1L),
+                ArgumentMatchers.eq(2L),
                 ArgumentMatchers.any()
         )).willReturn(response);
 
@@ -64,7 +68,7 @@ class CommentControllerTest {
 
         verify(commentService).createComment(
                 ArgumentMatchers.eq(1L),
-                ArgumentMatchers.eq(1L),
+                ArgumentMatchers.eq(2L),
                 ArgumentMatchers.any()
         );
     }
@@ -103,7 +107,7 @@ class CommentControllerTest {
 
         given(commentService.updateComment(
                 ArgumentMatchers.eq(1L),
-                ArgumentMatchers.eq(1L),
+                ArgumentMatchers.eq(2L),
                 ArgumentMatchers.any()
         )).willReturn(response);
 
@@ -118,7 +122,7 @@ class CommentControllerTest {
 
         verify(commentService).updateComment(
                 ArgumentMatchers.eq(1L),
-                ArgumentMatchers.eq(1L),
+                ArgumentMatchers.eq(2L),
                 ArgumentMatchers.any()
         );
     }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #30 
Closes #32 
Closes #33 
Closes #40 
Closes #41 
Closes #43 

## 🛠️ 작업 내용

### 1. 게시글 기준 댓글 작성/조회 안정화
- 댓글 작성 시 게시글 존재 여부를 검증하도록 수정했습니다.
- 댓글 목록 조회 시에도 게시글 존재 여부를 먼저 검증하도록 수정했습니다.

### 2. 댓글 목록 대댓글 계층 구조 응답 적용
- 댓글 목록 조회 응답에서 부모 댓글과 대댓글을 계층 구조로 내려주도록 수정했습니다.
- `CommentResponse`에 `replies` 필드를 추가하고, 부모 댓글 아래에 대댓글이 포함되도록 정리했습니다.

### 3. 댓글 알림/예외 처리 보강
- 삭제된 댓글에는 대댓글을 작성할 수 없도록 제한했습니다.
- 댓글 알림 수신자를 하드코딩된 사용자 값이 아니라 실제 게시글 작성자 기준으로 연결했습니다.
- 삭제된 부모 댓글에 대한 대댓글 시도 시 알림이 생성되지 않도록 처리했습니다.
- 댓글 API 예외 응답을 의미에 맞는 상태코드로 정리했습니다.
  - `EntityNotFoundException` → `404 NOT_FOUND`
  - `IllegalArgumentException`, `IllegalStateException` → `400 BAD_REQUEST`

### 4. 테스트 코드 수정
- `CommentControllerTest`, `CommentAttachmentControllerTest`, `NotificationControllerTest`의 테스트 설정을 보완했습니다.
- 현재 컨트롤러 구현과 맞도록 기대값 및 mock bean 설정을 수정했습니다.

### 5. 리팩토링
- 댓글 API 예외 처리 로직을 전역 핸들러로 이동했습니다.
- 댓글 서비스의 조회/검증 로직을 공통 메서드로 분리했습니다.
- 알림 생성 로직을 공통 메서드로 분리했습니다.
- 댓글 컨트롤러의 로그인 사용자 하드코딩 값을 한 곳에서 관리하도록 정리했습니다.

## ✅변경 파일

- `CommentController.java`
- `CommentServiceImpl.java`
- `CommentResponse.java`
- `NotificationServiceImpl.java`
- `GlobalExceptionHandler.java`
- `CommentControllerTest.java`
- `CommentAttachmentControllerTest.java`
- `NotificationControllerTest.java`


## 🧪테스트 내용

### 댓글 작성/조회
- 존재하는 게시글에 댓글 작성 성공 확인
- 존재하지 않는 게시글 요청 시 `404` 응답 확인

### 대댓글 계층 구조
- 댓글 목록 조회 시 부모 댓글 아래 `replies`로 대댓글이 포함되는지 확인

### 삭제된 댓글 대상 대댓글 작성 제한
- 삭제된 부모 댓글에 대댓글 작성 시 예외가 발생하는지 확인
- 삭제된 댓글에 대해서는 대댓글이 생성되지 않는 것 확인

### 댓글 알림
- 댓글 작성 시 실제 게시글 작성자 기준으로 `COMMENT` 알림이 생성되는지 확인
- 삭제된 부모 댓글에 대한 대댓글 시도 시 `REPLY` 알림이 생성되지 않는 것 확인
- 자기 자신에게는 알림이 생성되지 않는 기존 조건 유지 확인

### 예외 응답
- 존재하지 않는 게시글/댓글 요청 시 `404` 응답 확인
- 삭제된 댓글에 대댓글 작성 시도 시 `400` 응답 확인
- 응답 body에 `message` 필드가 포함되는지 확인

### 테스트 코드
- 관련 컨트롤러 테스트 전체 통과 확인

## 🎯 리뷰 포인트

- 댓글/대댓글 계층 구조 응답이 현재 프론트 사용 방식에 적절한지 확인 부탁드립니다.
- 삭제된 댓글 대상 대댓글 차단 로직이 서비스 계층에서 적절히 처리되었는지 확인 부탁드립니다.
- 댓글 알림 수신자를 실제 게시글 작성자 기준으로 조회하는 방식이 적절한지 확인 부탁드립니다.
- 전역 예외 처리로 옮긴 구조가 다른 도메인에도 확장 가능한 방향인지 확인 부탁드립니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="711" height="543" alt="image" src="https://github.com/user-attachments/assets/6a2b1793-06ed-45d8-8d64-9cd5a49926f0" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?