### PR TITLE
fix: 댓글 인증 테스트, 첨부파일 인증 흐름 및 알림 사용자 동기화 반영(#64, #68, #73)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
@@ -3,9 +3,17 @@ package com.back.devc.domain.interaction.notification.controller;
 import com.back.devc.domain.interaction.notification.dto.NotificationListResponse;
 import com.back.devc.domain.interaction.notification.dto.NotificationResponse;
 import com.back.devc.domain.interaction.notification.service.NotificationService;
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
+import com.back.devc.global.security.jwt.JwtPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.security.core.Authentication;
+
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -13,16 +21,45 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final MemberRepository memberRepository;
 
     @GetMapping
-    public ResponseEntity<NotificationListResponse> getMyNotifications() {
-        Long loginUserId = 1L;
-        return ResponseEntity.ok(notificationService.getMyNotifications(loginUserId));
+    public ResponseEntity<NotificationListResponse> getMyNotifications(Authentication authentication) {
+        return ResponseEntity.ok(notificationService.getMyNotifications(getAuthenticatedUserId(authentication)));
     }
 
     @PatchMapping("/{notificationId}/read")
-    public ResponseEntity<NotificationResponse> readNotification(@PathVariable Long notificationId) {
-        Long loginUserId = 1L;
-        return ResponseEntity.ok(notificationService.readNotification(notificationId, loginUserId));
+    public ResponseEntity<NotificationResponse> readNotification(
+            Authentication authentication,
+            @PathVariable Long notificationId
+    ) {
+        return ResponseEntity.ok(notificationService.readNotification(notificationId, getAuthenticatedUserId(authentication)));
+    }
+
+    private Long getAuthenticatedUserId(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof JwtPrincipal jwtPrincipal) {
+            return jwtPrincipal.userId();
+        }
+
+        if (principal instanceof OAuth2User oAuth2User) {
+            String email = oAuth2User.getAttribute("email");
+
+            if (email == null || email.isBlank()) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "OAuth 사용자 정보를 확인할 수 없습니다.");
+            }
+
+            Member member = memberRepository.findByEmail(email)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "회원을 찾을 수 없습니다."));
+
+            return member.getUserId();
+        }
+
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
@@ -3,11 +3,15 @@ package com.back.devc.domain.post.comment.attachment.controller;
 import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentDeleteResponse;
 import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentListResponse;
 import com.back.devc.domain.post.comment.attachment.service.CommentAttachmentService;
+import com.back.devc.global.security.jwt.JwtPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -20,10 +24,13 @@ public class CommentAttachmentController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommentAttachmentListResponse> uploadCommentAttachments(
+            @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long commentId,
             @RequestParam("files") List<MultipartFile> files,
             @RequestParam(value = "fileOrder", required = false) List<Integer> fileOrders
     ) {
+        getAuthenticatedUserId(principal);
+
         return ResponseEntity.ok(
                 commentAttachmentService.uploadAttachments(commentId, files, fileOrders)
         );
@@ -40,11 +47,21 @@ public class CommentAttachmentController {
 
     @DeleteMapping("/{attachmentId}")
     public ResponseEntity<CommentAttachmentDeleteResponse> deleteCommentAttachment(
+            @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long commentId,
             @PathVariable Long attachmentId
     ) {
+        getAuthenticatedUserId(principal);
+
         return ResponseEntity.ok(
                 commentAttachmentService.deleteAttachment(commentId, attachmentId)
         );
+    }
+
+    private Long getAuthenticatedUserId(JwtPrincipal principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+        return principal.userId();
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentServiceImpl.java
@@ -41,7 +41,7 @@ public class CommentAttachmentServiceImpl implements CommentAttachmentService {
             List<MultipartFile> files,
             List<Integer> fileOrders
     ) {
-        validateCommentExists(commentId);
+        Comment comment = validateComment(commentId);
 
         if (files == null || files.isEmpty()) {
             throw new IllegalArgumentException("업로드할 파일이 없습니다.");
@@ -104,7 +104,7 @@ public class CommentAttachmentServiceImpl implements CommentAttachmentService {
 
     @Override
     public CommentAttachmentListResponse getAttachments(Long commentId) {
-        validateCommentExists(commentId);
+        Comment comment = validateComment(commentId);
 
         List<CommentAttachmentResponse> attachments = commentAttachmentRepository
                 .findByCommentIdOrderByFileOrderAscIdAsc(commentId)
@@ -118,8 +118,12 @@ public class CommentAttachmentServiceImpl implements CommentAttachmentService {
     @Override
     @Transactional
     public CommentAttachmentDeleteResponse deleteAttachment(Long commentId, Long attachmentId) {
-        validateCommentExists(commentId);
+        Comment comment = validateComment(commentId);
 
+        // 현재 댓글 흐름은 soft delete 기반이므로, 삭제된 댓글의 첨부파일은 별도로 삭제 처리하지 않도록 한 번 더 방어
+        if (comment.isDeleted()) {
+            throw new IllegalStateException("삭제된 댓글의 첨부파일은 삭제할 수 없습니다.");
+        }
         CommentAttachment attachment = commentAttachmentRepository.findByIdAndCommentId(attachmentId, commentId)
                 .orElseThrow(() -> new EntityNotFoundException("댓글 첨부파일을 찾을 수 없습니다. id=" + attachmentId));
 
@@ -138,13 +142,17 @@ public class CommentAttachmentServiceImpl implements CommentAttachmentService {
         );
     }
 
-    private void validateCommentExists(Long commentId) {
+    private Comment validateComment(Long commentId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
 
+        // 현재 댓글 기능은 soft delete 기반으로 동작하므로,
+        // 삭제된 댓글에 대해서는 첨부파일 업로드/조회/삭제를 모두 막는다.
         if (comment.isDeleted()) {
             throw new IllegalStateException("삭제된 댓글에는 첨부파일을 처리할 수 없습니다.");
         }
+
+        return comment;
     }
 
     private CommentAttachmentResponse toResponse(CommentAttachment attachment) {

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
@@ -1,5 +1,11 @@
 package com.back.devc.domain.post.comment.attachment.controller;
 
+import com.back.devc.global.security.jwt.JwtPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import java.util.List;
+
 import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentDeleteResponse;
 import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentListResponse;
 import com.back.devc.domain.post.comment.attachment.service.CommentAttachmentService;
@@ -60,10 +66,15 @@ class CommentAttachmentControllerTest {
                 "dummy-image".getBytes()
         );
 
-        mockMvc.perform(multipart("/api/comments/{commentId}/attachments", 1L)
-                        .file(file)
-                        .param("fileOrder", "1"))
-                .andExpect(status().isOk());
+        SecurityContextHolder.getContext().setAuthentication(createAuthentication());
+        try {
+            mockMvc.perform(multipart("/api/comments/{commentId}/attachments", 1L)
+                            .file(file)
+                            .param("fileOrder", "1"))
+                    .andExpect(status().isOk());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
 
         verify(commentAttachmentService).uploadAttachments(eq(1L), anyList(), anyList());
     }
@@ -88,9 +99,18 @@ class CommentAttachmentControllerTest {
 
         given(commentAttachmentService.deleteAttachment(1L, 1L)).willReturn(response);
 
-        mockMvc.perform(delete("/api/comments/{commentId}/attachments/{attachmentId}", 1L, 1L))
-                .andExpect(status().isOk());
+        SecurityContextHolder.getContext().setAuthentication(createAuthentication());
+        try {
+            mockMvc.perform(delete("/api/comments/{commentId}/attachments/{attachmentId}", 1L, 1L))
+                    .andExpect(status().isOk());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
 
         verify(commentAttachmentService).deleteAttachment(1L, 1L);
+    }
+    private Authentication createAuthentication() {
+        JwtPrincipal principal = new JwtPrincipal(2L, "test@test.com", "USER");
+        return new UsernamePasswordAuthenticationToken(principal, null, List.of());
     }
 }

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
@@ -18,8 +18,15 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.back.devc.global.security.jwt.JwtPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.util.List;
+
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import org.springframework.security.core.context.SecurityContextHolder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -57,14 +64,19 @@ class CommentControllerTest {
                 ArgumentMatchers.any()
         )).willReturn(response);
 
-        mockMvc.perform(post("/api/posts/{postId}/comments", 1L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "content": "첫번째 댓글"
-                                }
-                                """))
-                .andExpect(status().isOk());
+        SecurityContextHolder.getContext().setAuthentication(createAuthentication());
+        try {
+            mockMvc.perform(post("/api/posts/{postId}/comments", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "content": "첫번째 댓글"
+                                    }
+                                    """))
+                    .andExpect(status().isOk());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
 
         verify(commentService).createComment(
                 ArgumentMatchers.eq(1L),
@@ -84,14 +96,19 @@ class CommentControllerTest {
                 ArgumentMatchers.any()
         )).willReturn(response);
 
-        mockMvc.perform(post("/api/comments/{commentId}/replies", 1L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "content": "대댓글입니다."
-                                }
-                                """))
-                .andExpect(status().isOk());
+        SecurityContextHolder.getContext().setAuthentication(createAuthentication());
+        try {
+            mockMvc.perform(post("/api/comments/{commentId}/replies", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "content": "대댓글입니다."
+                                    }
+                                    """))
+                    .andExpect(status().isOk());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
 
         verify(commentService).createReply(
                 ArgumentMatchers.eq(1L),
@@ -111,14 +128,19 @@ class CommentControllerTest {
                 ArgumentMatchers.any()
         )).willReturn(response);
 
-        mockMvc.perform(patch("/api/comments/{commentId}", 1L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "content": "수정된 댓글"
-                                }
-                                """))
-                .andExpect(status().isOk());
+        SecurityContextHolder.getContext().setAuthentication(createAuthentication());
+        try {
+            mockMvc.perform(patch("/api/comments/{commentId}", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "content": "수정된 댓글"
+                                    }
+                                    """))
+                    .andExpect(status().isOk());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
 
         verify(commentService).updateComment(
                 ArgumentMatchers.eq(1L),
@@ -134,8 +156,13 @@ class CommentControllerTest {
 
         given(commentService.deleteComment(1L, 2L)).willReturn(response);
 
-        mockMvc.perform(delete("/api/comments/{commentId}", 1L))
-                .andExpect(status().isOk());
+        SecurityContextHolder.getContext().setAuthentication(createAuthentication());
+        try {
+            mockMvc.perform(delete("/api/comments/{commentId}", 1L))
+                    .andExpect(status().isOk());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
 
         verify(commentService).deleteComment(1L, 2L);
     }
@@ -151,5 +178,10 @@ class CommentControllerTest {
                 .andExpect(status().isOk());
 
         verify(commentService).getComments(1L);
+    }
+
+    private Authentication createAuthentication() {
+        JwtPrincipal principal = new JwtPrincipal(2L, "test@test.com", "USER");
+        return new UsernamePasswordAuthenticationToken(principal, null, List.of());
     }
 }

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -30,6 +30,29 @@ type NotificationListResponse = {
   notifications: NotificationItem[]
 }
 
+async function ensureAuthReady() {
+  if (typeof window === "undefined") {
+    return false
+  }
+
+  const token = window.localStorage.getItem("accessToken")
+  if (token) {
+    return true
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/users/me`, {
+      method: "GET",
+      credentials: "include",
+      cache: "no-store",
+    })
+
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
 function normalizeNotification(notification: NotificationItem): NotificationItem {
   return {
     ...notification,
@@ -88,6 +111,22 @@ function dispatchNotificationsUpdated() {
   window.dispatchEvent(new CustomEvent("notifications-updated"))
 }
 
+function getAuthHeaders() {
+  if (typeof window === "undefined") {
+    return undefined
+  }
+
+  const token = window.localStorage.getItem("accessToken")
+
+  if (!token || token === "oauth-cookie-session") {
+    return undefined
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  }
+}
+
 function formatRelativeDate(createdAt: string) {
   const date = new Date(createdAt)
 
@@ -119,13 +158,49 @@ export default function NotificationsPage() {
   const [isAuthReady, setIsAuthReady] = useState(false)
 
   useEffect(() => {
-    const auth = getAuthSnapshot()
-    if (!auth.isLoggedIn) {
-      router.replace("/login")
-      return
+    let isMounted = true
+
+    const syncAuthState = async () => {
+      const localAuth = getAuthSnapshot()
+
+      if (localAuth.isLoggedIn) {
+        if (isMounted) {
+          setIsAuthReady(true)
+        }
+        return
+      }
+
+      const readyFromServer = await ensureAuthReady()
+
+      if (!isMounted) {
+        return
+      }
+
+      if (!readyFromServer) {
+        setNotifications([])
+        setIsAuthReady(false)
+        router.replace("/login")
+        return
+      }
+
+      setIsAuthReady(true)
     }
 
-    setIsAuthReady(true)
+    const handleAuthChanged = async () => {
+      setNotifications([])
+      await syncAuthState()
+    }
+
+    void syncAuthState()
+
+    window.addEventListener("auth-changed", handleAuthChanged)
+    window.addEventListener("storage", handleAuthChanged)
+
+    return () => {
+      isMounted = false
+      window.removeEventListener("auth-changed", handleAuthChanged)
+      window.removeEventListener("storage", handleAuthChanged)
+    }
   }, [router])
 
   const loadNotifications = async () => {
@@ -135,6 +210,8 @@ export default function NotificationsPage() {
 
       const response = await fetch(`${API_BASE_URL}/api/notifications`, {
         cache: "no-store",
+        headers: getAuthHeaders(),
+        credentials: "include",
       })
 
       if (!response.ok) {
@@ -171,10 +248,12 @@ export default function NotificationsPage() {
       await Promise.all(
         unreadNotifications.map(async (notification) => {
           const response = await fetch(
-            `${API_BASE_URL}/api/notifications/${notification.notificationId}/read`,
-            {
-              method: "PATCH",
-            }
+              `${API_BASE_URL}/api/notifications/${notification.notificationId}/read`,
+              {
+                method: "PATCH",
+                headers: getAuthHeaders(),
+                credentials: "include",
+              }
           )
 
           if (!response.ok) {
@@ -198,6 +277,8 @@ export default function NotificationsPage() {
 
       const response = await fetch(`${API_BASE_URL}/api/notifications/${notificationId}/read`, {
         method: "PATCH",
+        headers: getAuthHeaders(),
+        credentials: "include",
       })
 
       if (!response.ok) {

--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -23,6 +23,8 @@ type CommentListResponse = {
     comments: CommentItem[]
 }
 
+type ReplyFilesMap = Record<number, File[]>
+
 function getCurrentUserId(): number | null {
     if (typeof window === "undefined") {
         return null
@@ -105,6 +107,8 @@ export default function CommentSection({ postId }: CommentSectionProps) {
     const [editInputs, setEditInputs] = useState<Record<number, string>>({})
     const [editingSubmittingId, setEditingSubmittingId] = useState<number | null>(null)
     const [currentUserId, setCurrentUserId] = useState<number | null>(null)
+    const [newCommentFiles, setNewCommentFiles] = useState<File[]>([])
+    const [replyFiles, setReplyFiles] = useState<ReplyFilesMap>({})
 
     const loadComments = useCallback(async () => {
         try {
@@ -150,6 +154,34 @@ export default function CommentSection({ postId }: CommentSectionProps) {
         }
     }, [])
 
+    const uploadCommentAttachments = async (commentId: number, files: File[]) => {
+        if (files.length === 0) {
+            return
+        }
+
+        const formData = new FormData()
+
+        files.forEach((file, index) => {
+            formData.append("files", file)
+            formData.append("fileOrder", String(index + 1))
+        })
+
+        const token =
+            typeof window === "undefined"
+                ? null
+                : window.localStorage.getItem("accessToken")
+
+        const response = await fetch(`http://localhost:8080/api/comments/${commentId}/attachments`, {
+            method: "POST",
+            headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+            body: formData,
+        })
+
+        if (!response.ok) {
+            throw new Error("댓글 첨부파일 업로드에 실패했습니다.")
+        }
+    }
+
     const handleCreateComment = async () => {
         const trimmedComment = newComment.trim()
 
@@ -173,7 +205,14 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                 throw new Error("댓글 작성에 실패했습니다.")
             }
 
+            const createdComment = await response.json()
+
+            if (typeof createdComment?.commentId === "number" && newCommentFiles.length > 0) {
+                await uploadCommentAttachments(createdComment.commentId, newCommentFiles)
+            }
+
             setNewComment("")
+            setNewCommentFiles([])
             await loadComments()
         } catch (err) {
             setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
@@ -205,9 +244,19 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                 throw new Error("대댓글 작성에 실패했습니다.")
             }
 
+            const createdReply = await response.json()
+
+            if (typeof createdReply?.commentId === "number" && (replyFiles[commentId]?.length ?? 0) > 0) {
+                await uploadCommentAttachments(createdReply.commentId, replyFiles[commentId] ?? [])
+            }
+
             setReplyInputs((prev) => ({
                 ...prev,
                 [commentId]: "",
+            }))
+            setReplyFiles((prev) => ({
+                ...prev,
+                [commentId]: [],
             }))
             setOpenedReplyId(null)
             await loadComments()
@@ -298,7 +347,27 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                     placeholder="댓글을 입력하세요."
                     className="min-h-[96px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
                 />
-                <div className="flex justify-end">
+
+                <label className="mt-3 inline-flex w-fit cursor-pointer items-center rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground hover:bg-muted/50">
+                    파일 첨부
+                    <input
+                        type="file"
+                        multiple
+                        onChange={(event) => {
+                            setNewCommentFiles(Array.from(event.target.files ?? []))
+                        }}
+                        className="hidden"
+                    />
+                </label>
+
+                <div className="flex items-center justify-between gap-3">
+                    {newCommentFiles.length > 0 ? (
+                        <p className="text-xs text-muted-foreground">
+                            첨부파일 {newCommentFiles.length}개 선택됨
+                        </p>
+                    ) : (
+                        <p className="text-xs text-muted-foreground">선택된 첨부파일 없음</p>
+                    )}
                     <button
                         type="button"
                         onClick={handleCreateComment}
@@ -314,9 +383,7 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                 <p className="mt-4 text-sm text-muted-foreground">댓글을 불러오는 중입니다...</p>
             )}
 
-            {error && (
-                <p className="mt-4 text-sm text-destructive">{error}</p>
-            )}
+            {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
 
             {!loading && !error && comments.length === 0 && (
                 <p className="mt-4 text-sm text-muted-foreground">아직 댓글이 없습니다.</p>
@@ -327,16 +394,16 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                     <div key={comment.commentId} className="rounded-lg border border-border p-4">
                         {editingCommentId === comment.commentId ? (
                             <div className="space-y-2">
-        <textarea
-            value={editInputs[comment.commentId] ?? ""}
-            onChange={(e) =>
-                setEditInputs((prev) => ({
-                    ...prev,
-                    [comment.commentId]: e.target.value,
-                }))
-            }
-            className="min-h-[96px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-        />
+                                <textarea
+                                    value={editInputs[comment.commentId] ?? ""}
+                                    onChange={(e) =>
+                                        setEditInputs((prev) => ({
+                                            ...prev,
+                                            [comment.commentId]: e.target.value,
+                                        }))
+                                    }
+                                    className="min-h-[96px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                                />
                                 <div className="flex justify-end gap-2">
                                     <button
                                         type="button"
@@ -403,17 +470,41 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                             <div className="mt-4 ml-4 border-l-2 border-border/70 pl-4">
                                 <p className="mb-2 text-xs font-medium text-muted-foreground">이 댓글에 답글 달기</p>
                                 <div className="space-y-2 rounded-md bg-muted/30 p-3">
-            <textarea
-                value={replyInputs[comment.commentId] ?? ""}
-                onChange={(e) =>
-                    setReplyInputs((prev) => ({
-                        ...prev,
-                        [comment.commentId]: e.target.value,
-                    }))
-                }
-                placeholder="답글을 입력하세요."
-                className="min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-            />
+                                    <textarea
+                                        value={replyInputs[comment.commentId] ?? ""}
+                                        onChange={(e) =>
+                                            setReplyInputs((prev) => ({
+                                                ...prev,
+                                                [comment.commentId]: e.target.value,
+                                            }))
+                                        }
+                                        placeholder="답글을 입력하세요."
+                                        className="min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                                    />
+
+                                    <label className="mt-3 inline-flex w-fit cursor-pointer items-center rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground hover:bg-muted/50">
+                                        파일 첨부
+                                        <input
+                                            type="file"
+                                            multiple
+                                            onChange={(event) => {
+                                                setReplyFiles((prev) => ({
+                                                    ...prev,
+                                                    [comment.commentId]: Array.from(event.target.files ?? []),
+                                                }))
+                                            }}
+                                            className="hidden"
+                                        />
+                                    </label>
+
+                                    {(replyFiles[comment.commentId]?.length ?? 0) > 0 ? (
+                                        <p className="mt-2 text-xs text-muted-foreground">
+                                            첨부파일 {replyFiles[comment.commentId]?.length ?? 0}개 선택됨
+                                        </p>
+                                    ) : (
+                                        <p className="mt-2 text-xs text-muted-foreground">선택된 첨부파일 없음</p>
+                                    )}
+
                                     <div className="flex justify-end">
                                         <button
                                             type="button"
@@ -422,9 +513,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                                                 replySubmittingId === comment.commentId ||
                                                 !(replyInputs[comment.commentId] ?? "").trim()
                                             }
-                                            className="rounded-md bg-secondary px-3 py-2 text-sm font-medium text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                                            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
                                         >
-                                            {replySubmittingId === comment.commentId ? "작성 중..." : "답글 작성"}
+                                            {replySubmittingId === comment.commentId ? "답글 작성 중..." : "답글 작성"}
                                         </button>
                                     </div>
                                 </div>
@@ -437,16 +528,16 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                                     <div key={reply.commentId} className="rounded-md bg-muted/50 p-3 shadow-sm">
                                         {editingCommentId === reply.commentId ? (
                                             <div className="space-y-2">
-            <textarea
-                value={editInputs[reply.commentId] ?? ""}
-                onChange={(e) =>
-                    setEditInputs((prev) => ({
-                        ...prev,
-                        [reply.commentId]: e.target.value,
-                    }))
-                }
-                className="min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-            />
+                                                <textarea
+                                                    value={editInputs[reply.commentId] ?? ""}
+                                                    onChange={(e) =>
+                                                        setEditInputs((prev) => ({
+                                                            ...prev,
+                                                            [reply.commentId]: e.target.value,
+                                                        }))
+                                                    }
+                                                    className="min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                                                />
                                                 <div className="flex justify-end gap-2">
                                                     <button
                                                         type="button"

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -28,6 +28,22 @@ const categories = [
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
 
+function getAuthHeaders() {
+  if (typeof window === "undefined") {
+    return undefined
+  }
+
+  const token = window.localStorage.getItem("accessToken")
+
+  if (!token || token === "oauth-cookie-session") {
+    return undefined
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  }
+}
+
 type HeaderNotificationItem = {
   notificationId: number
   isRead?: boolean
@@ -125,12 +141,20 @@ export function Header() {
 
   useEffect(() => {
     let isMounted = true
-
     const loadNotifications = async () => {
+      const auth = getAuthSnapshot()
+
+      if (!auth.isLoggedIn) {
+        if (isMounted) {
+          setHasUnreadNotifications(false)
+        }
+        return
+      }
       try {
         const response = await fetch(`${API_BASE_URL}/api/notifications`, {
           cache: "no-store",
           credentials: "include",
+          headers: getAuthHeaders(),
         })
 
         if (!response.ok) {
@@ -155,17 +179,25 @@ export function Header() {
     }
 
     const handleNotificationsUpdated = () => {
-      void loadNotifications()
+      if (isLoggedIn) {
+        void loadNotifications()
+      } else {
+        setHasUnreadNotifications(false)
+      }
     }
 
-    void loadNotifications()
+    if (isLoggedIn) {
+      void loadNotifications()
+    } else {
+      setHasUnreadNotifications(false)
+    }
     window.addEventListener("notifications-updated", handleNotificationsUpdated)
 
     return () => {
       isMounted = false
       window.removeEventListener("notifications-updated", handleNotificationsUpdated)
     }
-  }, [])
+  }, [isLoggedIn])
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">


### PR DESCRIPTION
## 📌 관련 이슈

Closes #64 
Closes #68 
Closes #73 

### 1. CommentController 인증 기반 테스트 수정
- `CommentController`가 `@AuthenticationPrincipal JwtPrincipal` 기반으로 동작하도록 변경된 이후,
  기존 성공 테스트가 `401 UNAUTHORIZED`로 실패하던 문제를 수정했습니다.
- `CommentControllerTest`에서 `SecurityContextHolder`에 인증 객체를 직접 주입하도록 변경했습니다.
- 댓글 작성 / 대댓글 작성 / 댓글 수정 / 댓글 삭제 성공 테스트가 현재 인증 구조와 맞게 동작하도록 정리했습니다.

### 2. 댓글 첨부파일 인증 처리 반영
- `CommentAttachmentController`에서 첨부파일 업로드/삭제 시 로그인 사용자를 요구하도록 수정했습니다.
- 인증 정보가 없는 요청은 `401 UNAUTHORIZED`로 처리되도록 보완했습니다.

### 3. 댓글 첨부파일 soft delete 흐름 반영
- `CommentAttachmentServiceImpl`의 댓글 검증 로직을 정리했습니다.
- 삭제된 댓글에 대해서는 첨부파일 업로드 / 조회 / 삭제가 불가능하도록 방어 로직을 추가했습니다.
- 댓글 기능의 soft delete 정책과 첨부파일 처리 흐름이 일관되도록 맞췄습니다.

### 4. 첨부파일 컨트롤러 테스트 보완
- `CommentAttachmentControllerTest`에 인증 객체 주입 로직을 추가했습니다.
- 첨부 업로드/삭제 성공 테스트가 현재 인증 구조를 반영하도록 수정했습니다.

### 5. 알림 조회 사용자 식별 로직 수정
- `NotificationController`에서 알림 조회 및 읽음 처리 시 하드코딩된 사용자 id를 제거했습니다.
- 현재 로그인한 사용자 기준으로 알림을 조회/처리하도록 수정했습니다.
- 일반 이메일 로그인 사용자와 OAuth 로그인 사용자 모두 대응할 수 있도록 사용자 식별 흐름을 보완했습니다.

### 6. 알림 페이지 인증 동기화 보완
- `frontend/app/notifications/page.tsx`에서 알림 조회/읽음 처리 요청 시 인증 헤더와 쿠키 기반 인증을 함께 고려하도록 수정했습니다.
- 로그인 상태 변경 시 기존 알림 목록을 초기화하고 현재 사용자 기준으로 다시 동기화하도록 보완했습니다.

### 7. 헤더 종모양 알림 상태 동기화 보완
- `frontend/components/layout/header.tsx`에서 로그인 상태가 준비된 이후에만 알림 요청을 보내도록 수정했습니다.
- 비로그인 상태 또는 사용자 전환 직후 불필요한 알림 요청으로 인해 `401`이 발생하던 문제를 줄였습니다.
- 종모양 아이콘의 unread 표시가 현재 로그인 사용자 기준으로 갱신되도록 보완했습니다.


## 🎯 리뷰 포인트
- `SecurityContextHolder`를 이용한 테스트 인증 주입 방식이 현재 테스트 구조에 적절한지
- 댓글 첨부파일 업로드/삭제를 인증 필수로 두는 정책이 의도와 일치하는지
- soft delete 댓글에 대한 첨부파일 차단 로직이 현재 댓글 정책과 잘 맞는지
- 알림 조회가 현재 로그인 사용자 기준으로 정확히 동작하는지
- 이메일 로그인 / OAuth 로그인 사용자 간 인증 처리 방식이 현재 구조에서 안정적인지
- 헤더 종모양 unread 표시 동기화 방식이 적절한지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
알림 표시
<img width="261" height="40" alt="image" src="https://github.com/user-attachments/assets/b2ea684d-9b4b-49dd-81a3-ee1c6f47a56b" />
<img width="811" height="365" alt="image" src="https://github.com/user-attachments/assets/e5d7e78b-44c3-497a-9795-a4020a9857dd" />
알림 없는 계정 로그인시
<img width="817" height="392" alt="image" src="https://github.com/user-attachments/assets/41432e28-4df1-4913-9a45-837529de3efe" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?