### PR TITLE
Feature/#69 Oauth회원가입 시 닉네임 설정

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -112,7 +112,6 @@ public class OAuth2Controller {
         session.removeAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
 
         OAuthSignupCompleteResponse body = new OAuthSignupCompleteResponse(
-                accessToken,
                 member.getEmail(),
                 member.getNickname()
         );

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,20 +50,46 @@ public class OAuth2Controller {
     private String accessCookieSameSite;
 
     @GetMapping("/me")
-    public OAuth2MeResponse me(@AuthenticationPrincipal OAuth2User oauth2User) {
+    public OAuth2MeResponse me(
+            @AuthenticationPrincipal OAuth2User oauth2User,
+            HttpServletRequest httpServletRequest
+    ) {
+        HttpSession session = httpServletRequest.getSession(false);
+        if (session != null) {
+            Object raw = session.getAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
+            if (raw instanceof OAuthPendingSignup pending) {
+                Map<String, Object> attributes = new LinkedHashMap<>();
+                attributes.put("pendingSignup", true);
+                attributes.put("provider", pending.provider());
+                attributes.put("providerUserId", pending.providerUserId());
+                attributes.put("email", pending.emailFromProvider());
+                attributes.put("login", pending.loginFromProvider());
+
+                return new OAuth2MeResponse(
+                        false,
+                        null,
+                        List.of(),
+                        attributes
+                );
+            }
+        }
+
         if (oauth2User == null) {
-            return new OAuth2MeResponse(false, null, List.of(), Map.of());
+            return new OAuth2MeResponse(false, null, List.of(), Map.of("pendingSignup", false));
         }
 
         List<String> authorities = oauth2User.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .toList();
 
+        Map<String, Object> attributes = new LinkedHashMap<>(oauth2User.getAttributes());
+        attributes.put("pendingSignup", false);
+
         return new OAuth2MeResponse(
                 true,
                 oauth2User.getName(),
                 authorities,
-                oauth2User.getAttributes()
+                attributes
         );
     }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -90,12 +90,12 @@ public class OAuth2Controller {
     ) {
         HttpSession session = httpServletRequest.getSession(false);
         if (session == null) {
-            throw new ApiException(ErrorCode.UNAUTHORIZED);
+            throw new ApiException(ErrorCode.OAUTH2_PENDING_SIGNUP_EXPIRED);
         }
 
         Object raw = session.getAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
         if (!(raw instanceof OAuthPendingSignup pending)) {
-            throw new ApiException(ErrorCode.UNAUTHORIZED);
+            throw new ApiException(ErrorCode.OAUTH2_PENDING_SIGNUP_REQUIRED);
         }
 
         Member member = oAuth2MemberService.completeGithubSignup(pending, request.nickname());

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -3,7 +3,7 @@ package com.back.devc.domain.auth.controller;
 import com.back.devc.domain.auth.dto.OAuth2MeResponse;
 import com.back.devc.domain.auth.dto.oauth.OAuthPendingSignup;
 import com.back.devc.domain.auth.dto.oauth.OAuthSignupCompleteRequest;
-import com.back.devc.domain.auth.dto.signup.SignUpResponse;
+import com.back.devc.domain.auth.dto.oauth.OAuthSignupCompleteResponse;
 import com.back.devc.domain.auth.service.OAuth2MemberService;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.global.exception.ApiException;
@@ -65,12 +65,7 @@ public class OAuth2Controller {
                 attributes.put("email", pending.emailFromProvider());
                 attributes.put("login", pending.loginFromProvider());
 
-                return new OAuth2MeResponse(
-                        false,
-                        null,
-                        List.of(),
-                        attributes
-                );
+                return new OAuth2MeResponse(false, null, List.of(), attributes);
             }
         }
 
@@ -85,16 +80,11 @@ public class OAuth2Controller {
         Map<String, Object> attributes = new LinkedHashMap<>(oauth2User.getAttributes());
         attributes.put("pendingSignup", false);
 
-        return new OAuth2MeResponse(
-                true,
-                oauth2User.getName(),
-                authorities,
-                attributes
-        );
+        return new OAuth2MeResponse(true, oauth2User.getName(), authorities, attributes);
     }
 
     @PostMapping("/signup/complete")
-    public ResponseEntity<SuccessResponse<SignUpResponse>> completeSignup(
+    public ResponseEntity<SuccessResponse<OAuthSignupCompleteResponse>> completeSignup(
             @Valid @RequestBody OAuthSignupCompleteRequest request,
             HttpServletRequest httpServletRequest
     ) {
@@ -121,12 +111,10 @@ public class OAuth2Controller {
 
         session.removeAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
 
-        SignUpResponse body = new SignUpResponse(
-                member.getUserId(),
+        OAuthSignupCompleteResponse body = new OAuthSignupCompleteResponse(
+                accessToken,
                 member.getEmail(),
-                member.getNickname(),
-                member.getRole(),
-                member.getStatus()
+                member.getNickname()
         );
 
         SuccessCode successCode = SuccessCode.SIGN_UP_SUCCESS;

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -1,19 +1,52 @@
 package com.back.devc.domain.auth.controller;
 
 import com.back.devc.domain.auth.dto.OAuth2MeResponse;
+import com.back.devc.domain.auth.dto.oauth.OAuthPendingSignup;
+import com.back.devc.domain.auth.dto.oauth.OAuthSignupCompleteRequest;
+import com.back.devc.domain.auth.dto.signup.SignUpResponse;
+import com.back.devc.domain.auth.service.OAuth2MemberService;
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.global.exception.ApiException;
+import com.back.devc.global.exception.ErrorCode;
+import com.back.devc.global.response.SuccessCode;
+import com.back.devc.global.response.SuccessResponse;
+import com.back.devc.global.security.jwt.JwtProvider;
+import com.back.devc.global.security.oauth2.OAuth2LoginSuccessHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/auth/oauth2")
 public class OAuth2Controller {
+
+    private final OAuth2MemberService oAuth2MemberService;
+    private final JwtProvider jwtProvider;
+
+    @Value("${custom.jwt.access-token-expiration-seconds:3600}")
+    private long accessTokenExpirationSeconds;
+
+    @Value("${custom.jwt.access-cookie-name:access_token}")
+    private String accessCookieName;
+
+    @Value("${custom.jwt.access-cookie-secure:false}")
+    private boolean accessCookieSecure;
+
+    @Value("${custom.jwt.access-cookie-same-site:Lax}")
+    private String accessCookieSameSite;
 
     @GetMapping("/me")
     public OAuth2MeResponse me(@AuthenticationPrincipal OAuth2User oauth2User) {
@@ -31,5 +64,48 @@ public class OAuth2Controller {
                 authorities,
                 oauth2User.getAttributes()
         );
+    }
+
+    @PostMapping("/signup/complete")
+    public ResponseEntity<SuccessResponse<SignUpResponse>> completeSignup(
+            @Valid @RequestBody OAuthSignupCompleteRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        HttpSession session = httpServletRequest.getSession(false);
+        if (session == null) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Object raw = session.getAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
+        if (!(raw instanceof OAuthPendingSignup pending)) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Member member = oAuth2MemberService.completeGithubSignup(pending, request.nickname());
+
+        String accessToken = jwtProvider.createAccessToken(member);
+        ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
+                .httpOnly(true)
+                .secure(accessCookieSecure)
+                .path("/")
+                .maxAge(accessTokenExpirationSeconds)
+                .sameSite(accessCookieSameSite)
+                .build();
+
+        session.removeAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
+
+        SignUpResponse body = new SignUpResponse(
+                member.getUserId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getRole(),
+                member.getStatus()
+        );
+
+        SuccessCode successCode = SuccessCode.SIGN_UP_SUCCESS;
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .body(SuccessResponse.of(successCode, body));
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -133,7 +133,6 @@ public class OAuth2Controller {
             return oAuth2MemberService.completeKakaoSignup(pending, nickname);
         }
 
-        throw new ApiException(ErrorCode.BAD_REQUEST);
+        throw new ApiException(ErrorCode.OAUTH2_UNSUPPORTED_PROVIDER);
     }
-
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 @RestController
@@ -98,7 +99,7 @@ public class OAuth2Controller {
             throw new ApiException(ErrorCode.OAUTH2_PENDING_SIGNUP_REQUIRED);
         }
 
-        Member member = oAuth2MemberService.completeGithubSignup(pending, request.nickname());
+        Member member = completeByProvider(pending, request.nickname());
 
         String accessToken = jwtProvider.createAccessToken(member);
         ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
@@ -122,4 +123,17 @@ public class OAuth2Controller {
                 .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .body(SuccessResponse.of(successCode, body));
     }
+
+    private Member completeByProvider(OAuthPendingSignup pending, String nickname) {
+        String provider = pending.provider() == null ? "" : pending.provider().trim().toLowerCase(Locale.ROOT);
+
+        if ("github".equals(provider)) {
+            return oAuth2MemberService.completeGithubSignup(pending, nickname);
+        } else if ("kakao".equals(provider)) {
+            return oAuth2MemberService.completeKakaoSignup(pending, nickname);
+        }
+
+        throw new ApiException(ErrorCode.BAD_REQUEST);
+    }
+
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthPendingSignup.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthPendingSignup.java
@@ -1,0 +1,11 @@
+package com.back.devc.domain.auth.dto.oauth;
+
+import java.io.Serializable;
+
+public record OAuthPendingSignup(
+        String provider,
+        String providerUserId,
+        String emailFromProvider,
+        String loginFromProvider
+) implements Serializable {
+}

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteRequest.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteRequest.java
@@ -1,0 +1,11 @@
+package com.back.devc.domain.auth.dto.oauth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record OAuthSignupCompleteRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하입니다.")
+        String nickname
+) {
+}

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteResponse.java
@@ -1,0 +1,8 @@
+package com.back.devc.domain.auth.dto.oauth;
+
+public record OAuthSignupCompleteResponse(
+        String accessToken,
+        String email,
+        String nickname
+) {
+}

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteResponse.java
@@ -1,7 +1,6 @@
 package com.back.devc.domain.auth.dto.oauth;
 
 public record OAuthSignupCompleteResponse(
-        String accessToken,
         String email,
         String nickname
 ) {

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -3,6 +3,7 @@ package com.back.devc.domain.auth.service;
 import com.back.devc.domain.auth.dto.oauth.OAuthPendingSignup;
 import com.back.devc.domain.member.member.entity.AuthProvider;
 import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.entity.MemberStatus;
 import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.global.exception.ApiException;
 import com.back.devc.global.exception.ErrorCode;
@@ -105,7 +106,14 @@ public class OAuth2MemberService {
                 provider, pending.providerUserId()
         );
         if (existing.isPresent()) {
-            return existing.get();
+            Member member = existing.get();
+
+            // 가입완료 API 우회로로 블랙리스트 계정 토큰 발급되는 문제 방지
+            if (member.getStatus() == MemberStatus.BLACKLISTED) {
+                throw new ApiException(ErrorCode.MEMBER_BLACKLISTED);
+            }
+
+            return member;
         }
 
         String normalizedNickname = nickname == null ? "" : nickname.trim();

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -42,6 +42,10 @@ public class OAuth2MemberService {
 
     @Transactional
     public Member completeGithubSignup(OAuthPendingSignup pending, String nickname) {
+        if (pending == null || pending.providerUserId() == null || pending.providerUserId().isBlank()) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED);
+        }
+
         String normalizedNickname = nickname == null ? "" : nickname.trim();
         if (normalizedNickname.isBlank()) {
             throw new ApiException(ErrorCode.BAD_REQUEST);
@@ -51,7 +55,6 @@ public class OAuth2MemberService {
             throw new ApiException(ErrorCode.NICKNAME_ALREADY_EXISTS);
         }
 
-        // 이미 생성된 경우에는 기존 멤버 반환
         Optional<Member> existing = memberRepository.findByProviderAndProviderUserId(
                 AuthProvider.GITHUB, pending.providerUserId()
         );

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -38,7 +38,7 @@ public class OAuth2MemberService {
             return buildKakaoPendingSignup(oauth2User);
         }
 
-        throw new ApiException(ErrorCode.UNAUTHORIZED);
+        throw new ApiException(ErrorCode.OAUTH2_UNSUPPORTED_PROVIDER);
     }
 
     public Optional<Member> findMemberByProviderUserId(String provider, String providerUserId) {
@@ -49,7 +49,7 @@ public class OAuth2MemberService {
     public OAuthPendingSignup buildGithubPendingSignup(OAuth2User oauth2User) {
         String providerUserId = valueAsString(oauth2User.getAttribute("id")).trim();
         if (providerUserId.isBlank()) {
-            throw new IllegalStateException("GitHub 사용자 id를 찾을 수 없습니다.");
+            throw new ApiException(ErrorCode.OAUTH2_PROVIDER_USER_ID_MISSING);
         }
 
         String login = valueAsString(oauth2User.getAttribute("login")).trim();
@@ -61,7 +61,7 @@ public class OAuth2MemberService {
     public OAuthPendingSignup buildKakaoPendingSignup(OAuth2User oauth2User) {
         String providerUserId = valueAsString(oauth2User.getAttribute("id")).trim();
         if (providerUserId.isBlank()) {
-            throw new IllegalStateException("Kakao 사용자 id를 찾을 수 없습니다.");
+            throw new ApiException(ErrorCode.OAUTH2_PROVIDER_USER_ID_MISSING);
         }
 
         String email = "";
@@ -95,10 +95,10 @@ public class OAuth2MemberService {
             OAuthPendingSignup pending,
             String nickname,
             String fallbackEmailDomain,
-            String emailLocalPrefix
+            String localPrefix
     ) {
         if (pending == null || pending.providerUserId() == null || pending.providerUserId().isBlank()) {
-            throw new ApiException(ErrorCode.UNAUTHORIZED);
+            throw new ApiException(ErrorCode.OAUTH2_PENDING_SIGNUP_REQUIRED);
         }
 
         Optional<Member> existing = memberRepository.findByProviderAndProviderUserId(
@@ -121,7 +121,7 @@ public class OAuth2MemberService {
                 pending.emailFromProvider(),
                 pending.providerUserId(),
                 fallbackEmailDomain,
-                emailLocalPrefix
+                localPrefix
         );
         String encodedPassword = passwordEncoder.encode(UUID.randomUUID().toString());
 
@@ -147,7 +147,7 @@ public class OAuth2MemberService {
             return AuthProvider.KAKAO;
         }
 
-        throw new ApiException(ErrorCode.UNAUTHORIZED);
+        throw new ApiException(ErrorCode.OAUTH2_UNSUPPORTED_PROVIDER);
     }
 
     private String normalizeProvider(String provider) {

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -1,59 +1,80 @@
 package com.back.devc.domain.auth.service;
 
+import com.back.devc.domain.auth.dto.oauth.OAuthPendingSignup;
 import com.back.devc.domain.member.member.entity.AuthProvider;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
+import com.back.devc.global.exception.ApiException;
+import com.back.devc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class OAuth2MemberService {
 
-    private static final int MAX_NICKNAME_LENGTH = 50;
     private static final String GITHUB_EMAIL_DOMAIN = "@users.noreply.github.com";
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional
-    public Member getOrCreateGithubMember(OAuth2User oauth2User) {
+    public OAuthPendingSignup buildGithubPendingSignup(OAuth2User oauth2User) {
         String providerUserId = valueAsString(oauth2User.getAttribute("id")).trim();
-
         if (providerUserId.isBlank()) {
             throw new IllegalStateException("GitHub 사용자 id를 찾을 수 없습니다.");
         }
 
-        return memberRepository.findByProviderAndProviderUserId(AuthProvider.GITHUB, providerUserId)
-                .orElseGet(() -> createGithubMember(oauth2User, providerUserId));
+        String login = valueAsString(oauth2User.getAttribute("login")).trim();
+        String email = valueAsString(oauth2User.getAttribute("email")).trim();
+
+        return new OAuthPendingSignup("github", providerUserId, email, login);
     }
 
-    private Member createGithubMember(OAuth2User oauth2User, String providerUserId) {
-        String login = valueAsString(oauth2User.getAttribute("login"));
-        String email = valueAsString(oauth2User.getAttribute("email"));
+    public Optional<Member> findGithubMemberByProviderUserId(String providerUserId) {
+        return memberRepository.findByProviderAndProviderUserId(AuthProvider.GITHUB, providerUserId);
+    }
 
-        String resolvedEmail = resolveUniqueEmail(email, providerUserId);
-        String resolvedNickname = resolveUniqueNickname(login, providerUserId);
+    @Transactional
+    public Member completeGithubSignup(OAuthPendingSignup pending, String nickname) {
+        String normalizedNickname = nickname == null ? "" : nickname.trim();
+        if (normalizedNickname.isBlank()) {
+            throw new ApiException(ErrorCode.BAD_REQUEST);
+        }
+
+        if (memberRepository.existsByNickname(normalizedNickname)) {
+            throw new ApiException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
+        // 이미 생성된 경우에는 기존 멤버 반환
+        Optional<Member> existing = memberRepository.findByProviderAndProviderUserId(
+                AuthProvider.GITHUB, pending.providerUserId()
+        );
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        String resolvedEmail = resolveUniqueEmail(pending.emailFromProvider(), pending.providerUserId());
         String encodedPassword = passwordEncoder.encode(UUID.randomUUID().toString());
 
         Member newMember = Member.createOAuthMember(
                 AuthProvider.GITHUB,
-                providerUserId,
+                pending.providerUserId(),
                 resolvedEmail,
                 encodedPassword,
-                resolvedNickname
+                normalizedNickname
         );
 
         return memberRepository.save(newMember);
     }
 
     private String resolveUniqueEmail(String emailFromGithub, String providerUserId) {
-        if (!emailFromGithub.isBlank() && !memberRepository.existsByEmail(emailFromGithub)) {
+        if (emailFromGithub != null && !emailFromGithub.isBlank() && !memberRepository.existsByEmail(emailFromGithub)) {
             return emailFromGithub;
         }
 
@@ -67,52 +88,6 @@ public class OAuth2MemberService {
         }
 
         return candidate;
-    }
-
-    private String resolveUniqueNickname(String login, String providerUserId) {
-        String base = sanitizeNickname(login);
-        if (base.isBlank()) {
-            base = "github_" + providerUserId;
-        }
-        base = trimToMax(base, MAX_NICKNAME_LENGTH);
-
-        if (!memberRepository.existsByNickname(base)) {
-            return base;
-        }
-
-        int sequence = 1;
-        while (true) {
-            String suffix = "_" + sequence;
-            String prefix = trimToMax(base, MAX_NICKNAME_LENGTH - suffix.length());
-            String candidate = prefix + suffix;
-
-            if (!memberRepository.existsByNickname(candidate)) {
-                return candidate;
-            }
-
-            sequence++;
-        }
-    }
-
-    private String sanitizeNickname(String value) {
-        if (value == null) {
-            return "";
-        }
-
-        return value
-                .trim()
-                .replaceAll("\\s+", "_")
-                .replaceAll("[^a-zA-Z0-9._-]", "");
-    }
-
-    private String trimToMax(String value, int maxLength) {
-        if (value == null) {
-            return "";
-        }
-        if (value.length() <= maxLength) {
-            return value;
-        }
-        return value.substring(0, maxLength);
     }
 
     private String valueAsString(Object value) {

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -23,6 +24,21 @@ public class OAuth2MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+
+    public OAuthPendingSignup buildPendingSignup(String provider, OAuth2User oauth2User) {
+        String normalized = normalizeProvider(provider);
+
+        if ("github".equals(normalized)) {
+            return buildGithubPendingSignup(oauth2User);
+        }
+
+        throw new ApiException(ErrorCode.UNAUTHORIZED);
+    }
+
+    public Optional<Member> findMemberByProviderUserId(String provider, String providerUserId) {
+        AuthProvider authProvider = toAuthProvider(provider);
+        return memberRepository.findByProviderAndProviderUserId(authProvider, providerUserId);
+    }
 
     public OAuthPendingSignup buildGithubPendingSignup(OAuth2User oauth2User) {
         String providerUserId = valueAsString(oauth2User.getAttribute("id")).trim();
@@ -46,7 +62,6 @@ public class OAuth2MemberService {
             throw new ApiException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 1) 같은 OAuth 계정으로 이미 가입된 경우: 바로 반환 (멱등성 보장)
         Optional<Member> existing = memberRepository.findByProviderAndProviderUserId(
                 AuthProvider.GITHUB, pending.providerUserId()
         );
@@ -54,7 +69,6 @@ public class OAuth2MemberService {
             return existing.get();
         }
 
-        // 2) 신규 가입인 경우에만 닉네임 검증
         String normalizedNickname = nickname == null ? "" : nickname.trim();
         if (normalizedNickname.isBlank()) {
             throw new ApiException(ErrorCode.BAD_REQUEST);
@@ -76,6 +90,20 @@ public class OAuth2MemberService {
         );
 
         return memberRepository.save(newMember);
+    }
+
+    private AuthProvider toAuthProvider(String provider) {
+        String normalized = normalizeProvider(provider);
+
+        if ("github".equals(normalized)) {
+            return AuthProvider.GITHUB;
+        }
+
+        throw new ApiException(ErrorCode.UNAUTHORIZED);
+    }
+
+    private String normalizeProvider(String provider) {
+        return provider == null ? "" : provider.trim().toLowerCase(Locale.ROOT);
     }
 
     private String resolveUniqueEmail(String emailFromGithub, String providerUserId) {

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -46,6 +46,15 @@ public class OAuth2MemberService {
             throw new ApiException(ErrorCode.UNAUTHORIZED);
         }
 
+        // 1) 같은 OAuth 계정으로 이미 가입된 경우: 바로 반환 (멱등성 보장)
+        Optional<Member> existing = memberRepository.findByProviderAndProviderUserId(
+                AuthProvider.GITHUB, pending.providerUserId()
+        );
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        // 2) 신규 가입인 경우에만 닉네임 검증
         String normalizedNickname = nickname == null ? "" : nickname.trim();
         if (normalizedNickname.isBlank()) {
             throw new ApiException(ErrorCode.BAD_REQUEST);
@@ -53,13 +62,6 @@ public class OAuth2MemberService {
 
         if (memberRepository.existsByNickname(normalizedNickname)) {
             throw new ApiException(ErrorCode.NICKNAME_ALREADY_EXISTS);
-        }
-
-        Optional<Member> existing = memberRepository.findByProviderAndProviderUserId(
-                AuthProvider.GITHUB, pending.providerUserId()
-        );
-        if (existing.isPresent()) {
-            return existing.get();
         }
 
         String resolvedEmail = resolveUniqueEmail(pending.emailFromProvider(), pending.providerUserId());

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -30,6 +31,10 @@ public class OAuth2MemberService {
 
         if ("github".equals(normalized)) {
             return buildGithubPendingSignup(oauth2User);
+        }
+
+        if ("kakao".equals(normalized)) {
+            return buildKakaoPendingSignup(oauth2User);
         }
 
         throw new ApiException(ErrorCode.UNAUTHORIZED);
@@ -52,8 +57,26 @@ public class OAuth2MemberService {
         return new OAuthPendingSignup("github", providerUserId, email, login);
     }
 
-    public Optional<Member> findGithubMemberByProviderUserId(String providerUserId) {
-        return memberRepository.findByProviderAndProviderUserId(AuthProvider.GITHUB, providerUserId);
+    public OAuthPendingSignup buildKakaoPendingSignup(OAuth2User oauth2User) {
+        String providerUserId = valueAsString(oauth2User.getAttribute("id")).trim();
+        if (providerUserId.isBlank()) {
+            throw new IllegalStateException("Kakao 사용자 id를 찾을 수 없습니다.");
+        }
+
+        String email = "";
+        String login = "";
+
+        Object accountRaw = oauth2User.getAttribute("kakao_account");
+        if (accountRaw instanceof Map<?, ?> accountMap) {
+            email = valueAsString(accountMap.get("email")).trim();
+
+            Object profileRaw = accountMap.get("profile");
+            if (profileRaw instanceof Map<?, ?> profileMap) {
+                login = valueAsString(profileMap.get("nickname")).trim();
+            }
+        }
+
+        return new OAuthPendingSignup("kakao", providerUserId, email, login);
     }
 
     @Transactional
@@ -97,6 +120,10 @@ public class OAuth2MemberService {
 
         if ("github".equals(normalized)) {
             return AuthProvider.GITHUB;
+        }
+
+        if ("kakao".equals(normalized)) {
+            return AuthProvider.KAKAO;
         }
 
         throw new ApiException(ErrorCode.UNAUTHORIZED);

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuth2MemberService.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 public class OAuth2MemberService {
 
     private static final String GITHUB_EMAIL_DOMAIN = "@users.noreply.github.com";
+    private static final String KAKAO_EMAIL_DOMAIN = "@users.noreply.kakao.com";
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -81,12 +82,27 @@ public class OAuth2MemberService {
 
     @Transactional
     public Member completeGithubSignup(OAuthPendingSignup pending, String nickname) {
+        return completeSignupByProvider(AuthProvider.GITHUB, pending, nickname, GITHUB_EMAIL_DOMAIN, "github_");
+    }
+
+    @Transactional
+    public Member completeKakaoSignup(OAuthPendingSignup pending, String nickname) {
+        return completeSignupByProvider(AuthProvider.KAKAO, pending, nickname, KAKAO_EMAIL_DOMAIN, "kakao_");
+    }
+
+    private Member completeSignupByProvider(
+            AuthProvider provider,
+            OAuthPendingSignup pending,
+            String nickname,
+            String fallbackEmailDomain,
+            String emailLocalPrefix
+    ) {
         if (pending == null || pending.providerUserId() == null || pending.providerUserId().isBlank()) {
             throw new ApiException(ErrorCode.UNAUTHORIZED);
         }
 
         Optional<Member> existing = memberRepository.findByProviderAndProviderUserId(
-                AuthProvider.GITHUB, pending.providerUserId()
+                provider, pending.providerUserId()
         );
         if (existing.isPresent()) {
             return existing.get();
@@ -101,11 +117,16 @@ public class OAuth2MemberService {
             throw new ApiException(ErrorCode.NICKNAME_ALREADY_EXISTS);
         }
 
-        String resolvedEmail = resolveUniqueEmail(pending.emailFromProvider(), pending.providerUserId());
+        String resolvedEmail = resolveUniqueEmail(
+                pending.emailFromProvider(),
+                pending.providerUserId(),
+                fallbackEmailDomain,
+                emailLocalPrefix
+        );
         String encodedPassword = passwordEncoder.encode(UUID.randomUUID().toString());
 
         Member newMember = Member.createOAuthMember(
-                AuthProvider.GITHUB,
+                provider,
                 pending.providerUserId(),
                 resolvedEmail,
                 encodedPassword,
@@ -133,17 +154,24 @@ public class OAuth2MemberService {
         return provider == null ? "" : provider.trim().toLowerCase(Locale.ROOT);
     }
 
-    private String resolveUniqueEmail(String emailFromGithub, String providerUserId) {
-        if (emailFromGithub != null && !emailFromGithub.isBlank() && !memberRepository.existsByEmail(emailFromGithub)) {
-            return emailFromGithub;
+    private String resolveUniqueEmail(
+            String emailFromProvider,
+            String providerUserId,
+            String fallbackDomain,
+            String localPrefix
+    ) {
+        if (emailFromProvider != null
+                && !emailFromProvider.isBlank()
+                && !memberRepository.existsByEmail(emailFromProvider)) {
+            return emailFromProvider;
         }
 
-        String baseLocalPart = "github_" + providerUserId;
-        String candidate = baseLocalPart + GITHUB_EMAIL_DOMAIN;
+        String baseLocalPart = localPrefix + providerUserId;
+        String candidate = baseLocalPart + fallbackDomain;
         int sequence = 1;
 
         while (memberRepository.existsByEmail(candidate)) {
-            candidate = baseLocalPart + "_" + sequence + GITHUB_EMAIL_DOMAIN;
+            candidate = baseLocalPart + "_" + sequence + fallbackDomain;
             sequence++;
         }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/member/member/entity/AuthProvider.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/member/entity/AuthProvider.java
@@ -2,5 +2,6 @@ package com.back.devc.domain.member.member.entity;
 
 public enum AuthProvider {
     LOCAL,
-    GITHUB
+    GITHUB,
+    KAKAO
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/member/member/entity/Member.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/member/entity/Member.java
@@ -95,6 +95,18 @@ public class Member {
         );
     }
 
+    public static Member createLocalAdminMember(String email, String passwordHash, String nickname) {
+        return new Member(
+                email,
+                passwordHash,
+                nickname,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE,
+                AuthProvider.LOCAL,
+                email
+        );
+    }
+
     public static Member createOAuthMember(
             AuthProvider provider,
             String providerUserId,
@@ -115,6 +127,14 @@ public class Member {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updatePasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public void updateRole(MemberRole role) {
+        this.role = role;
     }
 
     @PrePersist

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
@@ -5,11 +5,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
-    ALREADY_DELETED(HttpStatus.GONE, "COMMON_410", "이미 삭제된 대상입니다."),
+    ALREADY_DELETED(HttpStatus.GONE, "COMMON_410", "이미 삭제된 리소스입니다."),
 
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404_EMAIL_NOT_FOUND", "존재하지 않는 이메일입니다."),
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH_401_PASSWORD_MISMATCH", "비밀번호가 일치하지 않습니다."),
-    MEMBER_BLACKLISTED(HttpStatus.FORBIDDEN, "AUTH_403_MEMBER_BLACKLISTED", "이용할 수 없는 계정입니다.(사유 : 경고 누적으로 인한 정지)"),
+    MEMBER_BLACKLISTED(HttpStatus.FORBIDDEN, "AUTH_403_MEMBER_BLACKLISTED", "이용할 수 없는 계정입니다."),
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_EXPIRED_TOKEN", "만료된 토큰입니다."),
@@ -19,12 +19,21 @@ public enum ErrorCode {
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409_EMAIL", "이미 사용 중인 이메일입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409_NICKNAME", "이미 사용 중인 닉네임입니다."),
 
-    // 신고 관련 에러 코드
-    REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "REPORT_409", "이미 신고 처리가 접수되었습니다."),
+    OAUTH2_PENDING_SIGNUP_REQUIRED(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH_401_OAUTH2_PENDING_SIGNUP_REQUIRED",
+            "OAuth 회원가입 정보가 없습니다. 다시 GitHub 로그인을 진행해주세요."
+    ),
+    OAUTH2_PENDING_SIGNUP_EXPIRED(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH_401_OAUTH2_PENDING_SIGNUP_EXPIRED",
+            "OAuth 회원가입 세션이 만료되었습니다. 다시 GitHub 로그인을 진행해주세요."
+    ),
+
+    REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "REPORT_409", "이미 신고 처리된 요청입니다."),
     CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST, "REPORT_400_SELF", "본인의 게시글이나 댓글은 신고할 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404", "존재하지 않는 게시글입니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_404", "존재하지 않는 댓글입니다."),
-    // 신고 Admin
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_404_NOT_FOUND", "해당 신고 내역을 찾을 수 없습니다."),
     REPORT_ALREADY_PROCESSED(HttpStatus.CONFLICT, "REPORT_409_ALREADY_PROCESSED", "이미 처리된 신고입니다.");
 

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
@@ -22,12 +22,22 @@ public enum ErrorCode {
     OAUTH2_PENDING_SIGNUP_REQUIRED(
             HttpStatus.UNAUTHORIZED,
             "AUTH_401_OAUTH2_PENDING_SIGNUP_REQUIRED",
-            "OAuth 회원가입 정보가 없습니다. 다시 GitHub 로그인을 진행해주세요."
+            "OAuth 회원가입 정보가 없습니다. 다시 로그인해주세요."
     ),
     OAUTH2_PENDING_SIGNUP_EXPIRED(
             HttpStatus.UNAUTHORIZED,
             "AUTH_401_OAUTH2_PENDING_SIGNUP_EXPIRED",
-            "OAuth 회원가입 세션이 만료되었습니다. 다시 GitHub 로그인을 진행해주세요."
+            "OAuth 회원가입 세션이 만료되었습니다. 다시 로그인해주세요."
+    ),
+    OAUTH2_UNSUPPORTED_PROVIDER(
+            HttpStatus.BAD_REQUEST,
+            "AUTH_400_OAUTH2_UNSUPPORTED_PROVIDER",
+            "지원하지 않는 OAuth 제공자입니다."
+    ),
+    OAUTH2_PROVIDER_USER_ID_MISSING(
+            HttpStatus.BAD_REQUEST,
+            "AUTH_400_OAUTH2_PROVIDER_USER_ID_MISSING",
+            "OAuth 제공자 사용자 식별값을 찾을 수 없습니다."
     ),
 
     REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "REPORT_409", "이미 신고 처리된 요청입니다."),

--- a/back/DevC/src/main/java/com/back/devc/global/initData/AdminAccountInitData.java
+++ b/back/DevC/src/main/java/com/back/devc/global/initData/AdminAccountInitData.java
@@ -1,0 +1,55 @@
+package com.back.devc.global.initData;
+
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminAccountInitData {
+
+    private static final String ADMIN_EMAIL = "admin@test.com";
+    private static final String ADMIN_PASSWORD = "admin123@";
+    private static final String ADMIN_NICKNAME_BASE = "admin";
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Bean
+    public ApplicationRunner adminAccountInitRunner() {
+        return args -> {
+            if (memberRepository.existsByEmail(ADMIN_EMAIL)) {
+                return;
+            }
+
+            String encodedPassword = passwordEncoder.encode(ADMIN_PASSWORD);
+            String nickname = resolveUniqueNickname(ADMIN_NICKNAME_BASE);
+
+            Member admin = Member.createLocalAdminMember(
+                    ADMIN_EMAIL,
+                    encodedPassword,
+                    nickname
+            );
+
+            memberRepository.save(admin);
+        };
+    }
+
+    private String resolveUniqueNickname(String base) {
+        if (!memberRepository.existsByNickname(base)) {
+            return base;
+        }
+
+        int sequence = 1;
+        String candidate = base + sequence;
+        while (memberRepository.existsByNickname(candidate)) {
+            sequence++;
+            candidate = base + sequence;
+        }
+        return candidate;
+    }
+}

--- a/back/DevC/src/main/java/com/back/devc/global/security/SecurityConfig.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,6 +19,7 @@ import org.springframework.security.web.header.writers.frameoptions.XFrameOption
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     @Bean
@@ -58,6 +60,7 @@ public class SecurityConfig {
                         .requestMatchers("/favicon.ico").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/users/me").authenticated()
                         .anyRequest().permitAll())
                 .cors(Customizer.withDefaults())

--- a/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.back.devc.global.security.oauth2;
 
+import com.back.devc.domain.auth.dto.oauth.OAuthPendingSignup;
 import com.back.devc.domain.auth.service.OAuth2MemberService;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.entity.MemberStatus;
@@ -7,6 +8,7 @@ import com.back.devc.global.security.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -18,10 +20,13 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    public static final String PENDING_SIGNUP_SESSION_KEY = "OAUTH2_PENDING_SIGNUP";
 
     private static final String ERROR_INVALID_PRINCIPAL = "OAUTH2_INVALID_PRINCIPAL";
     private static final String ERROR_MEMBER_BLACKLISTED = "OAUTH2_MEMBER_BLACKLISTED";
@@ -60,25 +65,35 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         }
 
         try {
-            Member member = oAuth2MemberService.getOrCreateGithubMember(oauth2User);
+            OAuthPendingSignup pending = oAuth2MemberService.buildGithubPendingSignup(oauth2User);
 
-            if (member.getStatus() == MemberStatus.BLACKLISTED) {
-                response.sendRedirect(redirectUrlResolver.buildFailureUrl(ERROR_MEMBER_BLACKLISTED));
+            Optional<Member> existing = oAuth2MemberService.findGithubMemberByProviderUserId(pending.providerUserId());
+            if (existing.isPresent()) {
+                Member member = existing.get();
+
+                if (member.getStatus() == MemberStatus.BLACKLISTED) {
+                    response.sendRedirect(redirectUrlResolver.buildFailureUrl(ERROR_MEMBER_BLACKLISTED));
+                    return;
+                }
+
+                String accessToken = jwtProvider.createAccessToken(member);
+                ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
+                        .httpOnly(true)
+                        .secure(accessCookieSecure)
+                        .path("/")
+                        .maxAge(accessTokenExpirationSeconds)
+                        .sameSite(accessCookieSameSite)
+                        .build();
+
+                response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+                response.sendRedirect(redirectUrlResolver.buildSuccessUrl(provider, member));
                 return;
             }
 
-            String accessToken = jwtProvider.createAccessToken(member);
+            HttpSession session = request.getSession(true);
+            session.setAttribute(PENDING_SIGNUP_SESSION_KEY, pending);
 
-            ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
-                    .httpOnly(true)
-                    .secure(accessCookieSecure)
-                    .path("/")
-                    .maxAge(accessTokenExpirationSeconds)
-                    .sameSite(accessCookieSameSite)
-                    .build();
-
-            response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-            response.sendRedirect(redirectUrlResolver.buildSuccessUrl(provider, member));
+            response.sendRedirect(redirectUrlResolver.buildSignupUrl(provider));
         } catch (Exception e) {
             response.sendRedirect(redirectUrlResolver.buildFailureUrl(ERROR_TOKEN_ISSUE));
         }

--- a/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -82,6 +82,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                     return;
                 }
 
+                // 기존 회원 로그인 성공 시, 남아 있을 수 있는 pending signup 세션 정리
+                HttpSession session = request.getSession(false);
+                if (session != null) {
+                    session.removeAttribute(PENDING_SIGNUP_SESSION_KEY);
+                }
+
                 String accessToken = jwtProvider.createAccessToken(member);
                 ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
                         .httpOnly(true)

--- a/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -30,6 +30,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private static final String ERROR_INVALID_PRINCIPAL = "OAUTH2_INVALID_PRINCIPAL";
     private static final String ERROR_MEMBER_BLACKLISTED = "OAUTH2_MEMBER_BLACKLISTED";
+    private static final String ERROR_UNSUPPORTED_PROVIDER = "OAUTH2_UNSUPPORTED_PROVIDER";
     private static final String ERROR_TOKEN_ISSUE = "OAUTH2_TOKEN_ISSUE";
 
     private final OAuth2MemberService oAuth2MemberService;
@@ -64,10 +65,15 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             provider = oauth2Token.getAuthorizedClientRegistrationId();
         }
 
-        try {
-            OAuthPendingSignup pending = oAuth2MemberService.buildGithubPendingSignup(oauth2User);
+        if (!isSupportedProvider(provider)) {
+            response.sendRedirect(redirectUrlResolver.buildFailureUrl(ERROR_UNSUPPORTED_PROVIDER));
+            return;
+        }
 
-            Optional<Member> existing = oAuth2MemberService.findGithubMemberByProviderUserId(pending.providerUserId());
+        try {
+            OAuthPendingSignup pending = oAuth2MemberService.buildPendingSignup(provider, oauth2User);
+
+            Optional<Member> existing = oAuth2MemberService.findMemberByProviderUserId(provider, pending.providerUserId());
             if (existing.isPresent()) {
                 Member member = existing.get();
 
@@ -97,5 +103,9 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         } catch (Exception e) {
             response.sendRedirect(redirectUrlResolver.buildFailureUrl(ERROR_TOKEN_ISSUE));
         }
+    }
+
+    private boolean isSupportedProvider(String provider) {
+        return "github".equalsIgnoreCase(provider) || "kakao".equalsIgnoreCase(provider);
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2RedirectUrlResolver.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2RedirectUrlResolver.java
@@ -19,7 +19,10 @@ public class OAuth2RedirectUrlResolver {
     @Value("${custom.oauth2.frontend-failure-url:http://localhost:3000/login}")
     private String frontendFailureUrl;
 
-    @Value("${custom.oauth2.allowed-redirect-uris:http://localhost:3000/login}")
+    @Value("${custom.oauth2.frontend-signup-url:http://localhost:3000/oauth/signup}")
+    private String frontendSignupUrl;
+
+    @Value("${custom.oauth2.allowed-redirect-uris:http://localhost:3000/login,http://localhost:3000/oauth/signup}")
     private String allowedRedirectUrisCsv;
 
     public String buildSuccessUrl(String provider, Member member) {
@@ -41,6 +44,16 @@ public class OAuth2RedirectUrlResolver {
         return UriComponentsBuilder.fromUriString(baseUrl)
                 .queryParam("oauth", "error")
                 .queryParam("errorCode", errorCode)
+                .build(true)
+                .toUriString();
+    }
+
+    public String buildSignupUrl(String provider) {
+        String baseUrl = resolveAllowedOrFallback(frontendSignupUrl, frontendFailureUrl);
+
+        return UriComponentsBuilder.fromUriString(baseUrl)
+                .queryParam("oauth", "pending_signup")
+                .queryParam("provider", provider)
                 .build(true)
                 .toUriString();
     }

--- a/back/DevC/src/main/resources/application-dev.yml
+++ b/back/DevC/src/main/resources/application-dev.yml
@@ -4,6 +4,7 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+
   security:
     oauth2:
       client:
@@ -13,19 +14,35 @@ spring:
             client-secret: ${GITHUB_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - profile_nickname
+              - account_email
+            client-name: Kakao
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 custom:
   oauth2:
-    # Outh2 로그인 성공 시 리디렉션할 URL (프론트엔드)
     frontend-success-url: http://localhost:3000/login
-    # Oauth2 로그인 실패 시 리디렉션할 URL (프론트엔드)
     frontend-failure-url: http://localhost:3000/login
-    # Oauth2 클라이언트에서 허용할 리디렉션 URI (프론트엔드)
-    allowed-redirect-uris: http://localhost:3000/login,http://localhost:3000/oauth/callback
+    frontend-signup-url: http://localhost:3000/oauth/signup
+    allowed-redirect-uris: http://localhost:3000/login,http://localhost:3000/oauth/signup,http://localhost:3000/oauth/callback
+
   cors:
-    # CORS 허용할 출처 (프론트엔드)
     allowed-origins: http://localhost:3000
+
   jwt:
-    # JWT 토큰의 비밀 키 (개발 환경에서는 간단한 키 사용)
     access-cookie-name: access_token
     access-cookie-secure: false
     access-cookie-same-site: Lax


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] OAuth 로그인 성공 후 기존 회원/신규 회원 분기 및 신규 사용자 /oauth/signup 리다이렉트 처리
- [x] 세션 기반 pending signup 도입 및 /api/auth/oauth2/me에서 pending 상태 반환
- [x] 닉네임만 입력받아 가입 완료(닉네임 중복 검증 포함)
- [x] OAuth 이메일 부재/중복 시 대체 이메일 자동 생성, 재요청 멱등 처리로 중복 가입 오류 방지
- [x] 가입 완료 응답에서 토큰 바디 제거하고 HttpOnly 쿠키 기반 인증으로 보안 정리
- [x] 구글 Oauth 추가
- [x] 관리자 아이디 생성

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?