### PR TITLE
Refactor/#84 oauth/이메일 로그인 인증 accessToken 단일 방식 변경 (#84)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -1,11 +1,15 @@
 package com.back.devc.domain.auth.controller;
 
 import com.back.devc.domain.auth.dto.OAuth2MeResponse;
+import com.back.devc.domain.auth.dto.login.LoginResponse;
+import com.back.devc.domain.auth.dto.oauth.OAuthExchangeRequest;
 import com.back.devc.domain.auth.dto.oauth.OAuthPendingSignup;
 import com.back.devc.domain.auth.dto.oauth.OAuthSignupCompleteRequest;
-import com.back.devc.domain.auth.dto.oauth.OAuthSignupCompleteResponse;
 import com.back.devc.domain.auth.service.OAuth2MemberService;
+import com.back.devc.domain.auth.service.OAuthLoginCodeService;
 import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.entity.MemberStatus;
+import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.global.exception.ApiException;
 import com.back.devc.global.exception.ErrorCode;
 import com.back.devc.global.response.SuccessCode;
@@ -16,9 +20,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,19 +37,9 @@ import java.util.Map;
 public class OAuth2Controller {
 
     private final OAuth2MemberService oAuth2MemberService;
+    private final OAuthLoginCodeService oAuthLoginCodeService;
+    private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
-
-    @Value("${custom.jwt.access-token-expiration-seconds:3600}")
-    private long accessTokenExpirationSeconds;
-
-    @Value("${custom.jwt.access-cookie-name:access_token}")
-    private String accessCookieName;
-
-    @Value("${custom.jwt.access-cookie-secure:false}")
-    private boolean accessCookieSecure;
-
-    @Value("${custom.jwt.access-cookie-same-site:Lax}")
-    private String accessCookieSameSite;
 
     @GetMapping("/me")
     public OAuth2MeResponse me(
@@ -84,8 +75,39 @@ public class OAuth2Controller {
         return new OAuth2MeResponse(true, oauth2User.getName(), authorities, attributes);
     }
 
+    @PostMapping("/exchange")
+    public ResponseEntity<SuccessResponse<LoginResponse>> exchange(
+            @Valid @RequestBody OAuthExchangeRequest request
+    ) {
+        Long userId = oAuthLoginCodeService.consume(request.code())
+                .orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getStatus() == MemberStatus.BLACKLISTED) {
+            throw new ApiException(ErrorCode.MEMBER_BLACKLISTED);
+        }
+
+        String accessToken = jwtProvider.createAccessToken(member);
+
+        LoginResponse body = new LoginResponse(
+                member.getUserId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getRole(),
+                member.getStatus(),
+                accessToken
+        );
+
+        SuccessCode successCode = SuccessCode.LOGIN_SUCCESS;
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, body));
+    }
+
     @PostMapping("/signup/complete")
-    public ResponseEntity<SuccessResponse<OAuthSignupCompleteResponse>> completeSignup(
+    public ResponseEntity<SuccessResponse<LoginResponse>> completeSignup(
             @Valid @RequestBody OAuthSignupCompleteRequest request,
             HttpServletRequest httpServletRequest
     ) {
@@ -100,27 +122,22 @@ public class OAuth2Controller {
         }
 
         Member member = completeByProvider(pending, request.nickname());
-
-        String accessToken = jwtProvider.createAccessToken(member);
-        ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
-                .httpOnly(true)
-                .secure(accessCookieSecure)
-                .path("/")
-                .maxAge(accessTokenExpirationSeconds)
-                .sameSite(accessCookieSameSite)
-                .build();
-
         session.removeAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
 
-        OAuthSignupCompleteResponse body = new OAuthSignupCompleteResponse(
+        String accessToken = jwtProvider.createAccessToken(member);
+
+        LoginResponse body = new LoginResponse(
+                member.getUserId(),
                 member.getEmail(),
-                member.getNickname()
+                member.getNickname(),
+                member.getRole(),
+                member.getStatus(),
+                accessToken
         );
 
-        SuccessCode successCode = SuccessCode.SIGN_UP_SUCCESS;
+        SuccessCode successCode = SuccessCode.LOGIN_SUCCESS;
         return ResponseEntity
                 .status(successCode.getStatus())
-                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .body(SuccessResponse.of(successCode, body));
     }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -100,7 +100,7 @@ public class OAuth2Controller {
                 accessToken
         );
 
-        SuccessCode successCode = SuccessCode.LOGIN_SUCCESS;
+        SuccessCode successCode = SuccessCode.SIGN_UP_SUCCESS;
         return ResponseEntity
                 .status(successCode.getStatus())
                 .body(SuccessResponse.of(successCode, body));

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthExchangeRequest.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthExchangeRequest.java
@@ -1,0 +1,9 @@
+package com.back.devc.domain.auth.dto.oauth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record OAuthExchangeRequest(
+        @NotBlank(message = "code는 필수입니다.")
+        String code
+) {
+}

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/dto/oauth/OAuthSignupCompleteResponse.java
@@ -1,7 +1,0 @@
-package com.back.devc.domain.auth.dto.oauth;
-
-public record OAuthSignupCompleteResponse(
-        String email,
-        String nickname
-) {
-}

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuthLoginCodeService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/service/OAuthLoginCodeService.java
@@ -1,0 +1,53 @@
+package com.back.devc.domain.auth.service;
+
+import com.back.devc.domain.member.member.entity.Member;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class OAuthLoginCodeService {
+
+    private static final long CODE_TTL_SECONDS = 120L;
+
+    private final Map<String, CodeEntry> codeStore = new ConcurrentHashMap<>();
+
+    public String issue(Member member) {
+        cleanupExpired();
+
+        String code = UUID.randomUUID().toString().replace("-", "");
+        Instant expiresAt = Instant.now().plusSeconds(CODE_TTL_SECONDS);
+
+        codeStore.put(code, new CodeEntry(member.getUserId(), expiresAt));
+        return code;
+    }
+
+    public Optional<Long> consume(String code) {
+        if (code == null || code.isBlank()) {
+            return Optional.empty();
+        }
+
+        CodeEntry entry = codeStore.remove(code.trim());
+        if (entry == null) {
+            return Optional.empty();
+        }
+
+        if (entry.expiresAt().isBefore(Instant.now())) {
+            return Optional.empty();
+        }
+
+        return Optional.of(entry.userId());
+    }
+
+    private void cleanupExpired() {
+        Instant now = Instant.now();
+        codeStore.entrySet().removeIf(e -> e.getValue().expiresAt().isBefore(now));
+    }
+
+    private record CodeEntry(Long userId, Instant expiresAt) {
+    }
+}

--- a/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -2,18 +2,14 @@ package com.back.devc.global.security.oauth2;
 
 import com.back.devc.domain.auth.dto.oauth.OAuthPendingSignup;
 import com.back.devc.domain.auth.service.OAuth2MemberService;
+import com.back.devc.domain.auth.service.OAuthLoginCodeService;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.entity.MemberStatus;
-import com.back.devc.global.security.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -23,7 +19,6 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.Optional;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
@@ -36,20 +31,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private static final String ERROR_TOKEN_ISSUE = "OAUTH2_TOKEN_ISSUE";
 
     private final OAuth2MemberService oAuth2MemberService;
-    private final JwtProvider jwtProvider;
     private final OAuth2RedirectUrlResolver redirectUrlResolver;
-
-    @Value("${custom.jwt.access-token-expiration-seconds:3600}")
-    private long accessTokenExpirationSeconds;
-
-    @Value("${custom.jwt.access-cookie-name:access_token}")
-    private String accessCookieName;
-
-    @Value("${custom.jwt.access-cookie-secure:false}")
-    private boolean accessCookieSecure;
-
-    @Value("${custom.jwt.access-cookie-same-site:Lax}")
-    private String accessCookieSameSite;
+    private final OAuthLoginCodeService oAuthLoginCodeService;
 
     @Override
     public void onAuthenticationSuccess(
@@ -84,24 +67,13 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                     return;
                 }
 
-                // 기존 회원 로그인 성공 시, 남아 있을 수 있는 pending signup 세션 정리
                 HttpSession session = request.getSession(false);
                 if (session != null) {
                     session.removeAttribute(PENDING_SIGNUP_SESSION_KEY);
                 }
 
-                String accessToken = jwtProvider.createAccessToken(member);
-
-                ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
-                        .httpOnly(true)
-                        .secure(accessCookieSecure)
-                        .path("/")
-                        .maxAge(accessTokenExpirationSeconds)
-                        .sameSite(accessCookieSameSite)
-                        .build();
-
-                response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-                response.sendRedirect(redirectUrlResolver.buildSuccessUrl(provider, member));
+                String authCode = oAuthLoginCodeService.issue(member);
+                response.sendRedirect(redirectUrlResolver.buildSuccessUrl(provider, authCode));
                 return;
             }
 
@@ -110,7 +82,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
             response.sendRedirect(redirectUrlResolver.buildSignupUrl(provider));
         } catch (Exception e) {
-            log.error("OAuth2 login success handler failed. provider={}", provider, e);
             response.sendRedirect(redirectUrlResolver.buildFailureUrl(ERROR_TOKEN_ISSUE));
         }
     }

--- a/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2RedirectUrlResolver.java
+++ b/back/DevC/src/main/java/com/back/devc/global/security/oauth2/OAuth2RedirectUrlResolver.java
@@ -1,6 +1,5 @@
 package com.back.devc.global.security.oauth2;
 
-import com.back.devc.domain.member.member.entity.Member;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -22,18 +21,16 @@ public class OAuth2RedirectUrlResolver {
     @Value("${custom.oauth2.frontend-signup-url:http://localhost:3000/oauth/signup}")
     private String frontendSignupUrl;
 
-    @Value("${custom.oauth2.allowed-redirect-uris:http://localhost:3000/login,http://localhost:3000/oauth/signup}")
+    @Value("${custom.oauth2.allowed-redirect-uris:http://localhost:3000/login,http://localhost:3000/oauth/signup,http://localhost:3000/oauth/callback}")
     private String allowedRedirectUrisCsv;
 
-    public String buildSuccessUrl(String provider, Member member) {
+    public String buildSuccessUrl(String provider, String authCode) {
         String baseUrl = resolveAllowedOrFallback(frontendSuccessUrl, frontendFailureUrl);
 
         return UriComponentsBuilder.fromUriString(baseUrl)
                 .queryParam("oauth", "success")
                 .queryParam("provider", provider)
-                .queryParam("userId", member.getUserId())
-                .queryParam("email", member.getEmail())
-                .queryParam("nickname", member.getNickname())
+                .queryParam("code", authCode)
                 .build()
                 .encode()
                 .toUriString();

--- a/back/DevC/src/main/resources/application-dev.yml
+++ b/back/DevC/src/main/resources/application-dev.yml
@@ -34,7 +34,7 @@ spring:
 
 custom:
   oauth2:
-    frontend-success-url: http://localhost:3000/login
+    frontend-success-url: http://localhost:3000/oauth/callback
     frontend-failure-url: http://localhost:3000/login
     frontend-signup-url: http://localhost:3000/oauth/signup
     allowed-redirect-uris: http://localhost:3000/login,http://localhost:3000/oauth/signup,http://localhost:3000/oauth/callback

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,108 +1,98 @@
-﻿"use client";
+﻿"use client"
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { Code2, Eye, EyeOff, Github } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
-import { login } from "@/lib/auth";
-import { persistLoginSession } from "@/lib/auth-storage";
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Code2, Eye, EyeOff, Github } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
+import { login } from "@/lib/auth"
+import { persistLoginSession } from "@/lib/auth-storage"
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
 
 function getOauthErrorMessage(errorCode: string | null) {
   switch (errorCode) {
     case "OAUTH2_CANCELLED":
-      return "로그인이 취소되었습니다.";
+      return "로그인이 취소되었습니다."
     case "OAUTH2_INVALID_STATE":
-      return "보안 검증에 실패했습니다. 다시 시도해주세요.";
+      return "보안 검증에 실패했습니다. 다시 시도해주세요."
     case "OAUTH2_MEMBER_BLACKLISTED":
-      return "이용이 제한된 계정입니다.";
+      return "이용이 제한된 계정입니다."
     case "OAUTH2_INVALID_PRINCIPAL":
-      return "OAuth 사용자 정보 처리에 실패했습니다.";
+      return "OAuth 사용자 정보 처리에 실패했습니다."
     case "OAUTH2_TOKEN_ISSUE":
-      return "토큰 발급에 실패했습니다.";
+      return "토큰 발급에 실패했습니다."
     case "OAUTH2_LOGIN_FAILED":
-      return "OAuth 로그인에 실패했습니다.";
+      return "OAuth 로그인에 실패했습니다."
     default:
-      return "OAuth 로그인 중 오류가 발생했습니다.";
+      return "OAuth 로그인 중 오류가 발생했습니다."
   }
 }
 
 export default function LoginPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
-  const [showPassword, setShowPassword] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [showPassword, setShowPassword] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState("")
   const [formData, setFormData] = useState({
     email: "",
     password: "",
     rememberMe: false,
-  });
+  })
 
   useEffect(() => {
-    const oauth = searchParams.get("oauth");
-    if (!oauth) return;
-
-    if (oauth === "success") {
-      const nickname = searchParams.get("nickname");
-      const email = searchParams.get("email");
-
-      persistLoginSession("oauth-cookie-session", nickname, email);
-      router.replace("/");
-      return;
-    }
+    const oauth = searchParams.get("oauth")
+    if (!oauth) return
 
     if (oauth === "pending_signup") {
-      router.replace("/oauth/signup");
-      return;
+      router.replace("/oauth/signup")
+      return
     }
 
     if (oauth === "error") {
-      const errorCode = searchParams.get("errorCode");
-      setError(getOauthErrorMessage(errorCode));
+      const errorCode = searchParams.get("errorCode")
+      setError(getOauthErrorMessage(errorCode))
     }
-  }, [searchParams, router]);
+  }, [searchParams, router])
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setIsLoading(true);
+    e.preventDefault()
+    setError("")
+    setIsLoading(true)
 
     try {
       const data = await login({
         email: formData.email,
         password: formData.password,
-      });
+      })
 
       if (!data.accessToken) {
-        throw new Error("토큰 응답이 없습니다.");
+        throw new Error("토큰 응답이 없습니다.")
       }
 
-      persistLoginSession(data.accessToken, data.nickname, data.email);
-      router.push("/");
+      persistLoginSession(data.accessToken, data.nickname, data.email)
+      router.push("/")
     } catch (err) {
-      setError(err instanceof Error ? err.message : "로그인에 실패했습니다.");
+      setError(err instanceof Error ? err.message : "로그인에 실패했습니다.")
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  };
+  }
 
   const handleGithubLogin = () => {
-    setError("");
-    window.location.href = `${API_BASE_URL}/oauth2/authorization/github`;
-  };
+    setError("")
+    window.location.href = `${API_BASE_URL}/oauth2/authorization/github`
+  }
 
   const handleKakaoLogin = () => {
-    setError("");
-    window.location.href = `${API_BASE_URL}/oauth2/authorization/kakao`;
-  };
+    setError("")
+    window.location.href = `${API_BASE_URL}/oauth2/authorization/kakao`
+  }
 
   return (
     <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
@@ -248,5 +238,5 @@ export default function LoginPage() {
         </p>
       </div>
     </div>
-  );
+  )
 }

--- a/frontend/app/oauth/callback/page.tsx
+++ b/frontend/app/oauth/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { persistLoginSession } from "@/lib/auth-storage"
+import { exchangeOAuthCode } from "@/lib/auth"
 
 export default function OAuthCallbackPage() {
   const router = useRouter()
@@ -10,30 +11,35 @@ export default function OAuthCallbackPage() {
 
   useEffect(() => {
     const oauth = searchParams.get("oauth")
-    const email = searchParams.get("email")
-    const nickname = searchParams.get("nickname")
     const errorCode = searchParams.get("errorCode")
+    const code = searchParams.get("code")
 
-    if (oauth === "error") {
-      const query = new URLSearchParams()
-
-      query.set("oauth", "error")
-
-      if (errorCode) {
-        query.set("errorCode", errorCode)
+    const run = async () => {
+      if (oauth === "error") {
+        const query = new URLSearchParams()
+        query.set("oauth", "error")
+        if (errorCode) query.set("errorCode", errorCode)
+        router.replace(`/login?${query.toString()}`)
+        return
       }
 
-      router.replace(`/login?${query.toString()}`)
-      return
+      if (oauth === "success" && code) {
+        try {
+          const data = await exchangeOAuthCode({ code })
+          persistLoginSession(data.accessToken, data.nickname, data.email)
+          router.replace("/mypage")
+          router.refresh()
+          return
+        } catch {
+          router.replace("/login?oauth=error&errorCode=OAUTH2_TOKEN_ISSUE")
+          return
+        }
+      }
+
+      router.replace("/login")
     }
 
-    if (oauth === "success") {
-      persistLoginSession(undefined, nickname, email)
-      router.replace("/mypage")
-      return
-    }
-
-    router.replace("/login")
+    void run()
   }, [router, searchParams])
 
   return (

--- a/frontend/app/oauth/signup/page.tsx
+++ b/frontend/app/oauth/signup/page.tsx
@@ -7,7 +7,7 @@ import { Code2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { completeOAuthSignup } from "@/lib/interaction"
+import { completeOAuthSignup } from "@/lib/auth"
 import { persistLoginSession, saveCurrentUserProfile } from "@/lib/auth-storage"
 
 export default function OAuthSignupPage() {
@@ -31,7 +31,7 @@ export default function OAuthSignupPage() {
     try {
       const data = await completeOAuthSignup({ nickname: trimmed })
 
-      persistLoginSession(undefined, data.nickname, data.email)
+      persistLoginSession(data.accessToken, data.nickname, data.email)
 
       saveCurrentUserProfile({
         email: data.email,
@@ -47,7 +47,7 @@ export default function OAuthSignupPage() {
       router.replace("/mypage")
       router.refresh()
     } catch (e) {
-      setError(e instanceof Error ? e.message : "닉네임 저장에 실패했습니다.")
+      setError(e instanceof Error ? e.message : "닉네임 설정에 실패했습니다.")
     } finally {
       setIsLoading(false)
     }
@@ -62,7 +62,7 @@ export default function OAuthSignupPage() {
             <span className="text-2xl font-bold text-foreground">DevHub</span>
           </Link>
           <p className="mt-2 text-muted-foreground">
-            GitHub 가입을 완료하려면 닉네임을 설정해주세요.
+            OAuth 가입을 완료하려면 닉네임을 설정해주세요.
           </p>
         </div>
 
@@ -88,7 +88,7 @@ export default function OAuthSignupPage() {
               className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
               disabled={isLoading}
             >
-              {isLoading ? "저장 중..." : "닉네임 저장하고 시작하기"}
+              {isLoading ? "저장 중..." : "닉네임 설정하고 시작하기"}
             </Button>
 
             {error ? <p className="text-sm text-destructive">{error}</p> : null}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -12,6 +12,14 @@ export type LoginRequest = {
   password: string
 }
 
+export type OAuthExchangeRequest = {
+  code: string
+}
+
+export type OAuthSignupCompleteRequest = {
+  nickname: string
+}
+
 export type LoginData = {
   userId: number
   email: string
@@ -19,7 +27,6 @@ export type LoginData = {
   role: string
   status: string
   accessToken: string
-  refreshToken: string
 }
 
 export type SignUpRequest = {
@@ -50,6 +57,35 @@ export async function signup(body: SignUpRequest): Promise<SignUpData> {
     method: "POST",
     body: JSON.stringify(body),
   })
+
+  return res.data
+}
+
+export async function exchangeOAuthCode(
+  body: OAuthExchangeRequest
+): Promise<LoginData> {
+  const res = await apiFetch<SuccessResponse<LoginData>>(
+    "/api/auth/oauth2/exchange",
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+    }
+  )
+
+  return res.data
+}
+
+export async function completeOAuthSignup(
+  body: OAuthSignupCompleteRequest
+): Promise<LoginData> {
+  const res = await apiFetch<SuccessResponse<LoginData>>(
+    "/api/auth/oauth2/signup/complete",
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+      auth: true,
+    }
+  )
 
   return res.data
 }


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #84

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] OAuth와 쿠키 발급 로직 공통화
- [x] 응답 스펙 정리
- [x] 쿠키 보안 설정 통일
- [x] OAuth code 교환 로그인으로 통일하고 프론트 인증 흐름 정리

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?