### PR TITLE
feat: 댓글 첨부 업로드 및 조회/렌더링 연동(#71)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
@@ -1,5 +1,7 @@
 package com.back.devc.domain.post.comment.dto;
 
+import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentResponse;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +25,7 @@ public class CommentResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<CommentResponse> replies;
+    private List<CommentAttachmentResponse> attachments;
 
     public static CommentResponse of(
             Long commentId,
@@ -46,6 +49,7 @@ public class CommentResponse {
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .replies(new ArrayList<>())
+                .attachments(new ArrayList<>())
                 .build();
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
@@ -10,6 +10,7 @@ import com.back.devc.domain.post.comment.entity.Comment;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
 import com.back.devc.domain.post.post.repository.PostRepository;
 import com.back.devc.domain.member.member.repository.MemberRepository;
+import com.back.devc.domain.post.comment.attachment.service.CommentAttachmentService;
 import com.back.devc.domain.member.member.entity.Member;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,8 @@ public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    // 댓글 조회 응답에 첨부파일 목록도 함께 담기 위해 사용하는 서비스
+    private final CommentAttachmentService commentAttachmentService;
     // 댓글/대댓글 작성 시 알림 기능과 연결하기 위해 주입한 서비스
     private final NotificationService notificationService;
 
@@ -185,7 +188,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     private CommentResponse toResponse(Comment comment) {
-        return CommentResponse.of(
+        CommentResponse response = CommentResponse.of(
                 comment.getId(),
                 comment.getPostId(),
                 comment.getUserId(),
@@ -196,5 +199,15 @@ public class CommentServiceImpl implements CommentService {
                 comment.getCreatedAt(),
                 comment.getUpdatedAt()
         );
+
+        // 삭제된 댓글은 현재 정책상 첨부파일을 노출하지 않고,
+        // 삭제되지 않은 댓글만 첨부파일 목록을 함께 내려준다.
+        if (!comment.isDeleted()) {
+            response.getAttachments().addAll(
+                    commentAttachmentService.getAttachments(comment.getId()).getAttachments()
+            );
+        }
+
+        return response;
     }
 }

--- a/frontend/app/post/[postId]/page.tsx
+++ b/frontend/app/post/[postId]/page.tsx
@@ -5,20 +5,17 @@ import { useParams } from "next/navigation"
 import CommentSection from "@/components/comment/CommentSection"
 
 type PostDetailResponse = {
-  id?: number | string
-  postId?: number | string
-  title?: string
-  content?: string
-  authorName?: string
-  nickname?: string
-  memberName?: string
-  writerName?: string
-  author?: {
-    name?: string
-    nickname?: string
-  }
-  createdAt?: string
-  likeCount?: number
+  postId: number
+  title: string
+  content: string
+  userId: number
+  nickName: string
+  categoryId: number
+  viewCount: number
+  likeCount: number
+  commentCount: number
+  createdAt: string
+  updatedAt: string
   liked?: boolean
   isLiked?: boolean
 }
@@ -57,14 +54,7 @@ export default function PostDetailPage() {
     return Number(rawPostId)
   }, [params])
 
-  const authorDisplayName =
-    post?.authorName ??
-    post?.nickname ??
-    post?.memberName ??
-    post?.writerName ??
-    post?.author?.name ??
-    post?.author?.nickname ??
-    "작성자 없음"
+  const authorDisplayName = post?.nickName ?? "작성자 없음"
 
   useEffect(() => {
     const loadPost = async () => {
@@ -77,22 +67,11 @@ export default function PostDetailPage() {
         setLoading(true)
         setError(null)
 
-        const endpoints = [`${API_BASE_URL}/api/posts/${postId}`, `${API_BASE_URL}/api/v1/posts/${postId}`]
-        let response: Response | null = null
+        const response = await fetch(`${API_BASE_URL}/api/posts/${postId}`, {
+          headers: getAuthHeaders(),
+        })
 
-        for (const endpoint of endpoints) {
-          const candidate = await fetch(endpoint, { headers: getAuthHeaders() })
-          if (candidate.ok) {
-            response = candidate
-            break
-          }
-          if (candidate.status !== 404) {
-            response = candidate
-            break
-          }
-        }
-
-        if (!response || !response.ok) {
+        if (!response.ok) {
           throw new Error("게시글을 불러오지 못했습니다.")
         }
 
@@ -168,9 +147,13 @@ export default function PostDetailPage() {
           <div>
             <h1 className="text-2xl font-bold text-foreground">{post?.title ?? "제목 없음"}</h1>
             <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-              <span>게시글 ID: {postId}</span>
+              <span>게시글 ID: {post?.postId ?? postId}</span>
               <span>작성자: {authorDisplayName}</span>
+              <span>카테고리 ID: {post?.categoryId ?? "-"}</span>
+              <span>조회수: {post?.viewCount ?? 0}</span>
+              <span>댓글 수: {post?.commentCount ?? 0}</span>
               {post?.createdAt ? <span>작성일: {post.createdAt}</span> : null}
+              {post?.updatedAt ? <span>수정일: {post.updatedAt}</span> : null}
             </div>
             <div className="mt-6 whitespace-pre-wrap rounded-lg bg-muted/30 p-4 text-sm leading-7 text-foreground">
               {post?.content ?? "내용이 없습니다."}

--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -1,9 +1,18 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
+import { getAccessToken } from "@/lib/auth-storage"
 
 type CommentSectionProps = {
     postId: number
+}
+
+type CommentAttachmentItem = {
+    attachmentId: number
+    fileName: string
+    fileUrl: string
+    fileType?: string | null
+    mimeType?: string | null
 }
 
 type CommentItem = {
@@ -16,6 +25,7 @@ type CommentItem = {
     createdAt: string
     updatedAt: string
     deleted: boolean
+    attachments?: CommentAttachmentItem[]
     replies: CommentItem[]
 }
 
@@ -23,15 +33,80 @@ type CommentListResponse = {
     comments: CommentItem[]
 }
 
+type CreatedCommentApiResponse = {
+    id?: number
+    commentId?: number
+    data?: {
+        id?: number
+        commentId?: number
+        comment?: {
+            id?: number
+            commentId?: number
+        }
+    }
+}
+
+/**
+ * 댓글/대댓글 생성 응답에서 실제 commentId 를 꺼낸다.
+ *
+ * 다양한 백엔드 응답 형식에 대응한다.
+ */
+function extractCreatedCommentId(responseBody: unknown): number | null {
+    if (!responseBody || typeof responseBody !== "object") {
+        return null
+    }
+
+    const candidate = responseBody as CreatedCommentApiResponse
+
+    const possibleIds = [
+        candidate.commentId,
+        candidate.id,
+        candidate.data?.commentId,
+        candidate.data?.id,
+        candidate.data?.comment?.commentId,
+        candidate.data?.comment?.id,
+    ]
+
+    const validId = possibleIds.find((value) => typeof value === "number")
+
+    return typeof validId === "number" ? validId : null
+}
+
 type ReplyFilesMap = Record<number, File[]>
+
+/**
+ * 현재 auth-storage 에는 공통 fetch 헬퍼가 없어서,
+ * 댓글 영역에서는 임시로 JWT/OAuth 공통 인증 옵션을 로컬에서 구성한다.
+ *
+ * - 일반 로그인 사용자는 Bearer 토큰 사용
+ * - OAuth 로그인 사용자는 credentials: include 기반 세션 인증 사용
+ */
+const OAUTH_SESSION_PLACEHOLDER_TOKEN = "oauth-cookie-session"
+
+function hasLocalJwtToken(token: string | null | undefined): boolean {
+    return Boolean(token) && token !== OAUTH_SESSION_PLACEHOLDER_TOKEN
+}
+
+function getAuthFetchOptions(): Pick<RequestInit, "credentials" | "headers"> {
+    const token = getAccessToken()
+
+    return {
+        credentials: "include",
+        headers: hasLocalJwtToken(token)
+            ? {
+                Authorization: `Bearer ${token}`,
+            }
+            : undefined,
+    }
+}
 
 function getCurrentUserId(): number | null {
     if (typeof window === "undefined") {
         return null
     }
 
-    const token = window.localStorage.getItem("accessToken")
-    if (!token) {
+    const token = getAccessToken()
+    if (!hasLocalJwtToken(token)) {
         return null
     }
 
@@ -61,27 +136,61 @@ function getCurrentUserId(): number | null {
     }
 }
 
-function getAuthHeaders(): Record<string, string> {
-    if (typeof window === "undefined") {
-        return {
-            "Content-Type": "application/json",
-        }
-    }
-
-    const token = window.localStorage.getItem("accessToken")
-
-    if (!token) {
-        return {
-            "Content-Type": "application/json",
-        }
-    }
-
+function getJsonAuthHeaders(): Record<string, string> {
     return {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+        ...(getAuthFetchOptions().headers ?? {}),
     }
 }
 
+
+function isImageAttachment(attachment: CommentAttachmentItem): boolean {
+    const normalizedFileType = attachment.fileType?.toUpperCase()
+    const normalizedMimeType = attachment.mimeType?.toLowerCase()
+
+    return normalizedFileType === "IMAGE" || normalizedMimeType?.startsWith("image/") === true
+}
+
+function renderAttachments(attachments: CommentAttachmentItem[] | undefined) {
+    if (!attachments || attachments.length === 0) {
+        return null
+    }
+
+    return (
+        <div className="mt-3 space-y-3">
+            <p className="text-xs font-medium text-muted-foreground">첨부파일</p>
+            <div className="flex flex-col gap-3">
+                {attachments.map((attachment) => {
+                    const fileUrl = `http://localhost:8080${attachment.fileUrl}`
+                    const isImage = isImageAttachment(attachment)
+
+                    return (
+                        <div
+                            key={attachment.attachmentId}
+                            className="flex flex-col gap-2 rounded-md border border-border/70 p-3"
+                        >
+                            {isImage && (
+                                <img
+                                    src={fileUrl}
+                                    alt={attachment.fileName}
+                                    className="max-h-80 w-fit max-w-full rounded-md border border-border object-contain"
+                                />
+                            )}
+                            <a
+                                href={fileUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="w-fit text-sm text-primary underline-offset-2 hover:underline"
+                            >
+                                {attachment.fileName}
+                            </a>
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
 
 function sortCommentsByNewest(comments: CommentItem[]): CommentItem[] {
     return [...comments]
@@ -154,6 +263,14 @@ export default function CommentSection({ postId }: CommentSectionProps) {
         }
     }, [])
 
+    /**
+     * 댓글/대댓글 작성 직후 첨부파일을 업로드한다.
+     *
+     * - 일반 로그인 사용자는 Authorization 헤더 기반으로 인증
+     * - OAuth 로그인 사용자는 credentials: include 기반 세션 인증
+     *
+     * FormData 요청이라 Content-Type 은 직접 지정하지 않고 브라우저에 맡긴다.
+     */
     const uploadCommentAttachments = async (commentId: number, files: File[]) => {
         if (files.length === 0) {
             return
@@ -166,14 +283,11 @@ export default function CommentSection({ postId }: CommentSectionProps) {
             formData.append("fileOrder", String(index + 1))
         })
 
-        const token =
-            typeof window === "undefined"
-                ? null
-                : window.localStorage.getItem("accessToken")
+        const authOptions = getAuthFetchOptions()
 
         const response = await fetch(`http://localhost:8080/api/comments/${commentId}/attachments`, {
+            ...authOptions,
             method: "POST",
-            headers: token ? { Authorization: `Bearer ${token}` } : undefined,
             body: formData,
         })
 
@@ -194,8 +308,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
             setError(null)
 
             const response = await fetch(`http://localhost:8080/api/posts/${postId}/comments`, {
+                ...getAuthFetchOptions(),
                 method: "POST",
-                headers: getAuthHeaders(),
+                headers: getJsonAuthHeaders(),
                 body: JSON.stringify({
                     content: trimmedComment,
                 }),
@@ -206,9 +321,14 @@ export default function CommentSection({ postId }: CommentSectionProps) {
             }
 
             const createdComment = await response.json()
+            const createdCommentId = extractCreatedCommentId(createdComment)
 
-            if (typeof createdComment?.commentId === "number" && newCommentFiles.length > 0) {
-                await uploadCommentAttachments(createdComment.commentId, newCommentFiles)
+            if (newCommentFiles.length > 0) {
+                if (createdCommentId === null) {
+                    throw new Error("댓글은 생성됐지만 생성된 commentId를 응답에서 찾지 못해 첨부 업로드를 진행하지 못했습니다.")
+                }
+
+                await uploadCommentAttachments(createdCommentId, newCommentFiles)
             }
 
             setNewComment("")
@@ -233,8 +353,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
             setError(null)
 
             const response = await fetch(`http://localhost:8080/api/comments/${commentId}/replies`, {
+                ...getAuthFetchOptions(),
                 method: "POST",
-                headers: getAuthHeaders(),
+                headers: getJsonAuthHeaders(),
                 body: JSON.stringify({
                     content,
                 }),
@@ -245,9 +366,14 @@ export default function CommentSection({ postId }: CommentSectionProps) {
             }
 
             const createdReply = await response.json()
+            const createdReplyId = extractCreatedCommentId(createdReply)
 
-            if (typeof createdReply?.commentId === "number" && (replyFiles[commentId]?.length ?? 0) > 0) {
-                await uploadCommentAttachments(createdReply.commentId, replyFiles[commentId] ?? [])
+            if ((replyFiles[commentId]?.length ?? 0) > 0) {
+                if (createdReplyId === null) {
+                    throw new Error("답글은 생성됐지만 생성된 commentId를 응답에서 찾지 못해 첨부 업로드를 진행하지 못했습니다.")
+                }
+
+                await uploadCommentAttachments(createdReplyId, replyFiles[commentId] ?? [])
             }
 
             setReplyInputs((prev) => ({
@@ -273,8 +399,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
             setError(null)
 
             const response = await fetch(`http://localhost:8080/api/comments/${commentId}`, {
+                ...getAuthFetchOptions(),
                 method: "DELETE",
-                headers: getAuthHeaders(),
+                headers: getJsonAuthHeaders(),
             })
 
             if (!response.ok) {
@@ -316,8 +443,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
             setError(null)
 
             const response = await fetch(`http://localhost:8080/api/comments/${commentId}`, {
+                ...getAuthFetchOptions(),
                 method: "PATCH",
-                headers: getAuthHeaders(),
+                headers: getJsonAuthHeaders(),
                 body: JSON.stringify({
                     content,
                 }),
@@ -426,7 +554,10 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                                 </div>
                             </div>
                         ) : (
-                            <p className="text-sm text-foreground">{comment.content}</p>
+                            <>
+                                <p className="text-sm text-foreground">{comment.content}</p>
+                                {renderAttachments(comment.attachments)}
+                            </>
                         )}
 
                         <div className="mt-2 flex items-center justify-between gap-3">
@@ -560,7 +691,10 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                                                 </div>
                                             </div>
                                         ) : (
-                                            <p className="text-sm text-foreground">{reply.content}</p>
+                                            <>
+                                                <p className="text-sm text-foreground">{reply.content}</p>
+                                                {renderAttachments(reply.attachments)}
+                                            </>
                                         )}
 
                                         <div className="mt-2 flex items-center justify-between gap-3">


### PR DESCRIPTION
## 📌 관련 이슈

Closes #71

## 🛠️ 작업 내용
### 1. 댓글/대댓글 작성 후 첨부파일 업로드 연동
- 댓글 또는 대댓글 작성 성공 후 생성된 `commentId`를 기반으로 첨부파일 업로드 요청이 이어지도록 수정했습니다.
- 댓글 생성 응답 형식이 다를 수 있어 `commentId` 추출 로직을 보완했습니다.
- JWT 로그인과 OAuth 세션 로그인 모두 첨부 업로드 요청이 가능하도록 인증 처리도 함께 반영했습니다.

### 2. 댓글 응답 DTO에 첨부파일 목록 추가
- `CommentResponse`에 `attachments` 필드를 추가했습니다.
- 댓글 조회 응답에서 첨부파일 목록을 함께 내려줄 수 있도록 구조를 확장했습니다.

### 3. 댓글 조회 시 첨부파일 목록 포함
- `CommentServiceImpl`에서 댓글 응답 생성 시 첨부파일 목록도 함께 조회하도록 수정했습니다.
- 삭제되지 않은 댓글에 대해서만 첨부파일 목록을 응답에 포함하도록 처리했습니다.

### 4. 프론트 댓글 첨부 렌더링 추가
- `CommentSection.tsx`에서 댓글/대댓글 응답의 `attachments`를 렌더링하도록 수정했습니다.
- 일반 파일은 다운로드/열기 링크로 표시되도록 처리했습니다.
- 이미지 파일은 댓글 아래에서 바로 미리보기되도록 처리했습니다.

### 5. 첨부 렌더링 방식 보완
- 이미지 파일은 `fileType` 또는 `mimeType` 기준으로 판별하도록 구현했습니다.
- 이미지인 경우 댓글 본문 아래에서 바로 확인할 수 있게 `<img>` 미리보기 UI를 추가했습니다.

## 🎯 리뷰 포인트
- 댓글 응답 DTO에 첨부파일 목록을 포함시키는 방식이 현재 구조에 적절한지
- `CommentServiceImpl`에서 첨부파일 조회를 함께 수행하는 방식이 괜찮은지
- 삭제된 댓글에 첨부파일을 포함하지 않는 현재 정책이 적절한지
- 프론트에서 이미지/비이미지 첨부파일을 나누어 렌더링하는 방식이 자연스러운지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="593" height="818" alt="image" src="https://github.com/user-attachments/assets/d6070b5b-698b-4b7e-9404-6e7755ea147c" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?