### PR TITLE
feat: 북마크 생성 시 알림 연동 및 상세 페이지 북마크 UI 추가(#94)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/service/BookmarkService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/service/BookmarkService.java
@@ -8,6 +8,7 @@ import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.domain.post.post.entity.Post;
 import com.back.devc.domain.post.post.repository.PostRepository;
+import com.back.devc.domain.interaction.notification.service.NotificationService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,8 @@ public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    // 북마크 생성 성공 후 게시글 작성자에게 북마크 알림을 보내기 위해 사용하는 서비스
+    private final NotificationService notificationService;
 
     @Transactional
     public BookmarkResponse createBookmark(Long userId, Long postId) {
@@ -38,6 +41,10 @@ public class BookmarkService {
 
         Bookmark bookmark = new Bookmark(member, post);
         bookmarkRepository.save(bookmark);
+
+        // 북마크 저장이 끝난 뒤 게시글 작성자에게 북마크 알림을 생성
+        // 실제 알림 생성 가능 여부(자기 글 북마크인지, 중복 알림인지 등)는 NotificationService 에서 한 번 더 검증
+        notificationService.createBookmarkNotification(postId, userId);
 
         return new BookmarkResponse(post.getPostId(), true);
     }

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
@@ -11,6 +11,14 @@ public interface NotificationService {
 
     void createPostLikeNotification(Long postId, Long actorUserId);
 
+    /**
+     * 게시글 북마크 알림 생성
+     *
+     * 북마크를 누른 사용자가 actorUserId,
+     * 북마크된 게시글의 작성자가 알림 수신자가 됨
+     */
+    void createBookmarkNotification(Long postId, Long actorUserId);
+
     void createReportNotification(Long targetUserId, Long actorUserId, Long postId, String message);
 
     NotificationListResponse getMyNotifications(Long loginUserId);

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.List;
  * - COMMENT : 내 게시글에 다른 사용자가 댓글을 남긴 경우
  * - REPLY   : 내 댓글에 다른 사용자가 답글을 남긴 경우
  * - LIKE    : 내 게시글에 다른 사용자가 좋아요를 누른 경우
+ * - BOOKMARK: 내 게시글을 다른 사용자가 북마크한 경우
  * - REPORT  : 내 게시글/댓글이 신고된 경우
  *
  * 구현 시 주의한 점
@@ -136,6 +137,40 @@ public class NotificationServiceImpl implements NotificationService {
                 null,
                 "LIKE",
                 actorUserId + "번 사용자가 회원님의 게시글을 좋아합니다."
+        );
+    }
+
+    /**
+     * 게시글 북마크 알림 생성
+     *
+     * 주의 사항
+     * - 자기 자신의 게시글을 북마크한 경우 알림을 만들지 않음
+     * - 같은 사용자가 같은 게시글을 북마크 취소 후 다시 눌러도
+     *   BOOKMARK 알림은 한 번만 남기도록 중복 생성 방지 검사를 수행
+     */
+    @Override
+    @Transactional
+    public void createBookmarkNotification(Long postId, Long actorUserId) {
+        Long postOwnerId = findPostOwnerId(postId);
+
+        if (postOwnerId.equals(actorUserId)) {
+            return;
+        }
+
+        boolean alreadyNotified = notificationRepository
+                .existsByUserIdAndActorUserIdAndPostIdAndType(postOwnerId, actorUserId, postId, "BOOKMARK");
+
+        if (alreadyNotified) {
+            return;
+        }
+
+        saveNotification(
+                postOwnerId,
+                actorUserId,
+                postId,
+                null,
+                "BOOKMARK",
+                actorUserId + "번 사용자가 회원님의 게시글을 북마크했습니다."
         );
     }
 

--- a/frontend/app/post/[postId]/page.tsx
+++ b/frontend/app/post/[postId]/page.tsx
@@ -14,6 +14,8 @@ type PostDetailResponse = {
   viewCount: number
   likeCount: number
   commentCount: number
+  bookmarkCount?: number
+  bookmarked?: boolean
   createdAt: string
   updatedAt: string
   liked?: boolean
@@ -45,6 +47,9 @@ export default function PostDetailPage() {
   const [liked, setLiked] = useState(false)
   const [likeCount, setLikeCount] = useState(0)
   const [likeLoading, setLikeLoading] = useState(false)
+  const [bookmarked, setBookmarked] = useState(false)
+  const [bookmarkLoading, setBookmarkLoading] = useState(false)
+  const [bookmarkCount, setBookmarkCount] = useState(0)
 
   const postId = useMemo(() => {
     const rawPostId = params?.postId
@@ -79,6 +84,8 @@ export default function PostDetailPage() {
         setPost(data)
         setLiked(Boolean(data?.isLiked ?? data?.liked ?? false))
         setLikeCount(typeof data?.likeCount === "number" ? data.likeCount : 0)
+        setBookmarked(Boolean(data?.bookmarked ?? false))
+        setBookmarkCount(typeof data?.bookmarkCount === "number" ? data.bookmarkCount : 0)
       } catch (err) {
         setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
       } finally {
@@ -89,6 +96,33 @@ export default function PostDetailPage() {
     void loadPost()
   }, [postId])
 
+  const handleToggleBookmark = async () => {
+    if (!postId || Number.isNaN(postId)) {
+      return
+    }
+
+    try {
+      setBookmarkLoading(true)
+      setError(null)
+
+      const response = await fetch(`${API_BASE_URL}/api/posts/${postId}/bookmarks`, {
+        method: bookmarked ? "DELETE" : "POST",
+        headers: getAuthHeaders(),
+      })
+
+      if (!response.ok) {
+        throw new Error(bookmarked ? "북마크 취소에 실패했습니다." : "북마크에 실패했습니다.")
+      }
+
+      setBookmarked((prev) => !prev)
+      setBookmarkCount((prev) => (bookmarked ? Math.max(prev - 1, 0) : prev + 1))
+      window.dispatchEvent(new CustomEvent("notifications-updated"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
+    } finally {
+      setBookmarkLoading(false)
+    }
+  }
   const handleToggleLike = async () => {
     if (!postId || Number.isNaN(postId)) {
       return
@@ -168,6 +202,15 @@ export default function PostDetailPage() {
                 {likeLoading ? "처리 중..." : liked ? "좋아요 취소" : "좋아요"}
               </button>
               <span className="text-sm text-muted-foreground">좋아요 {likeCount}</span>
+              <button
+                type="button"
+                onClick={handleToggleBookmark}
+                disabled={bookmarkLoading}
+                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {bookmarkLoading ? "처리 중..." : bookmarked ? "북마크 취소" : "북마크"}
+              </button>
+              <span className="text-sm text-muted-foreground">북마크 {bookmarkCount}</span>
             </div>
           </div>
         )}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #94 

## 🛠️ 작업 내용
### 1. 북마크 알림 서비스 메서드 추가
- `NotificationService`에 `createBookmarkNotification(Long postId, Long actorUserId)` 메서드를 추가했습니다.
- 북마크 알림이 어떤 역할을 하는지 인터페이스 수준에서 주석으로 정리했습니다.

### 2. 북마크 알림 생성 로직 구현
- `NotificationServiceImpl`에 BOOKMARK 알림 생성 로직을 추가했습니다.
- 처리 정책은 다음과 같습니다.
  - 자기 자신의 게시글을 북마크한 경우 알림 생성 제외
  - 같은 사용자가 같은 게시글을 북마크 취소 후 다시 북마크해도 BOOKMARK 알림은 한 번만 생성
- 게시글 작성자를 receiver, 북마크를 누른 사용자를 actor로 하여 알림을 저장하도록 구현했습니다.

### 3. 북마크 생성 시 알림 연동
- `BookmarkService`의 `createBookmark(...)`에서 북마크 저장 성공 직후
  `notificationService.createBookmarkNotification(postId, userId)`를 호출하도록 수정했습니다.
- 북마크 저장 자체와 알림 생성 책임을 분리하고,
  실제 알림 생성 가능 여부는 `NotificationService`에서 한 번 더 검증하도록 구성했습니다.

### 4. 게시글 상세 페이지 북마크 상태 추가
- `frontend/app/post/[postId]/page.tsx`에서 게시글 상세조회 응답에
  `bookmarked`, `bookmarkCount`를 반영할 수 있도록 상태를 추가했습니다.
- 상세조회 응답 기준으로 초기 북마크 상태와 북마크 수를 세팅하도록 수정했습니다.

### 5. 게시글 상세 페이지 북마크 버튼 추가
- 게시글 상세 페이지에 북마크 토글 버튼을 추가했습니다.
- `POST /api/posts/{postId}/bookmarks`
- `DELETE /api/posts/{postId}/bookmarks`
를 사용해 북마크 생성/취소가 가능하도록 구현했습니다.
- 북마크 성공 시 `notifications-updated` 이벤트를 발생시켜 헤더 알림 상태와 동기화되도록 했습니다.

### 6. 북마크 수 표시 추가
- 상세 페이지에서 좋아요 수와 동일한 방식으로 북마크 수를 표시하도록 UI를 보완했습니다.
- 북마크 추가 시 +1, 취소 시 -1 되도록 로컬 상태를 반영했습니다.

## 🎯 리뷰 포인트
- BOOKMARK 알림을 `NotificationService`에서 생성하도록 분리한 방식이 적절한지
- 자기 글 북마크 및 중복 북마크 알림 방지 정책이 현재 서비스 구조와 잘 맞는지
- `BookmarkService`에서 저장 후 알림 생성 호출하는 흐름이 자연스러운지
- 상세 페이지 북마크 상태/개수 UI 반영 방식이 적절한지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="627" height="232" alt="테스트 게시글 1" src="https://github.com/user-attachments/assets/4dadc445-3545-4c5f-8911-c1a748d2f582" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?