### PR TITLE
feat: 게시글 상세 북마크 정보 반영 및 상세 링크 수정

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/repository/BookmarkRepository.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/repository/BookmarkRepository.java
@@ -15,4 +15,19 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByMemberAndPost(Member member, Post post);
 
     List<Bookmark> findAllByMember(Member member);
+
+    /**
+     * 현재 로그인한 사용자가 특정 게시글을 북마크했는지 확인
+     *
+     * 게시글 상세조회 응답에서 bookmarked 값을 내려주기 위해 사용
+     */
+    boolean existsByMember_UserIdAndPost_PostId(Long userId, Long postId);
+
+    /**
+     * 특정 게시글의 전체 북마크 수를 조회
+     *
+     * 게시글 상세 페이지에서 북마크 수를 바로 표시할 수 있도록
+     * 상세조회 응답에 bookmarkCount 를 포함할 때 사용
+     */
+    long countByPost_PostId(Long postId);
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/post/dto/PostDetailResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/post/dto/PostDetailResponse.java
@@ -14,15 +14,29 @@ public record PostDetailResponse(
         int viewCount,
         int likeCount,
         int commentCount,
+        // 게시글 상세 화면에서 북마크 수를 바로 표시하기 위해 함께 내려주는 값
+        int bookmarkCount,
+        // 현재 로그인 사용자가 이 게시글을 북마크했는지 여부
+        boolean bookmarked,
         boolean liked,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static PostDetailResponse from(Post post) {
-        return from(post, false);
+        return from(post, false, false, 0);
     }
 
     public static PostDetailResponse from(Post post, boolean liked) {
+        return from(post, liked, false, 0);
+    }
+
+    /**
+     * 게시글 상세조회 응답 생성
+     *
+     * liked / bookmarked 는 현재 로그인 사용자를 기준으로 계산한 상태값이고,
+     * bookmarkCount 는 상세 페이지에서 별도 추가 조회 없이 바로 북마크 수를 표시하기 위해 포함
+     */
+    public static PostDetailResponse from(Post post, boolean liked, boolean bookmarked, int bookmarkCount) {
         return new PostDetailResponse(
                 post.getPostId(),
                 post.getTitle(),
@@ -33,6 +47,8 @@ public record PostDetailResponse(
                 post.getViewCount(),
                 post.getLikeCount(),
                 post.getCommentCount(),
+                bookmarkCount,
+                bookmarked,
                 liked,
                 post.getCreatedAt(),
                 post.getUpdatedAt()

--- a/back/DevC/src/main/java/com/back/devc/domain/post/post/service/PostService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.back.devc.domain.post.post.service;
 
 import com.back.devc.domain.interaction.postLike.repository.PostLikeRepository;
+import com.back.devc.domain.interaction.bookmark.repository.BookmarkRepository;
 import com.back.devc.domain.post.post.dto.PostDetailResponse;
 
 import com.back.devc.domain.member.member.entity.Member;
@@ -29,6 +30,8 @@ public class PostService {
     private final CategoryRepository categoryRepository;
     // 게시글 상세 조회 시 현재 로그인 사용자의 좋아요 여부를 확인하기 위해 추가한 repository
     private final PostLikeRepository postLikeRepository;
+    // 게시글 상세 조회 시 현재 로그인 사용자의 북마크 여부와 북마크 수를 확인하기 위해 추가한 repository
+    private final BookmarkRepository bookmarkRepository;
 
     // 게시글 작성
     public Post write(Long userId, Long categoryId, String title, String content) {
@@ -54,7 +57,7 @@ public class PostService {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId));
     }
-    
+
     // 단건 상세 조회 (현재 로그인 사용자의 좋아요 여부 포함)
     // 게시글이 현재 isDeleted=false인 경우만 상세 조회 할 수 있도록 변경하였습니다.
 
@@ -78,8 +81,16 @@ public class PostService {
         boolean liked = loginUserId != null
                 && postLikeRepository.existsByMember_UserIdAndPost_PostId(loginUserId, postId);
 
-        // 게시글 기본 정보와 현재 로그인 사용자의 좋아요 여부를 함께 응답 DTO로 변환
-        return PostDetailResponse.from(post, liked);
+        // 비로그인 사용자는 북마크 여부를 확인할 수 없으므로 false 처리
+        // 로그인 사용자라면 bookmarks 테이블을 조회해서 현재 게시글을 북마크했는지 확인
+        boolean bookmarked = loginUserId != null
+                && bookmarkRepository.existsByMember_UserIdAndPost_PostId(loginUserId, postId);
+
+        // 상세 페이지에서 북마크 수를 바로 표시할 수 있도록 현재 게시글의 북마크 총 개수도 함께 계산
+        int bookmarkCount = Math.toIntExact(bookmarkRepository.countByPost_PostId(postId));
+
+        // 게시글 기본 정보와 현재 로그인 사용자의 좋아요/북마크 여부, 북마크 수를 함께 응답 DTO로 변환
+        return PostDetailResponse.from(post, liked, bookmarked, bookmarkCount);
     }
 
 
@@ -197,6 +208,4 @@ public class PostService {
 
         post.delete();
     }
-
-
 }

--- a/frontend/components/post-card.tsx
+++ b/frontend/components/post-card.tsx
@@ -40,7 +40,7 @@ export function PostCard({ post }: PostCardProps) {
             <span className="text-xs text-muted-foreground">{post.createdAt}</span>
           </div>
 
-          <Link href={`/post/${post.id}`}>
+          <Link href={`/posts/${post.id}`}>
             <h3 className="mb-2 text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
               {post.title}
             </h3>


### PR DESCRIPTION
## 📌 관련 이슈

## 🛠️ 작업 내용
### 1. 게시글 상세조회 응답에 북마크 정보 추가
- `PostDetailResponse`에 다음 필드를 추가했습니다.
  - `bookmarkCount`
  - `bookmarked`
- 기존 상세조회 응답이 좋아요 상태만 포함하고 있어,
  프론트에서 북마크 수와 현재 사용자의 북마크 여부를 정확히 표시할 수 없던 문제를 보완했습니다.

### 2. 게시글 상세 서비스에서 북마크 상태/수 계산
- `PostService.findDetailById(...)`에서
  - 현재 로그인 사용자의 북마크 여부
  - 해당 게시글의 전체 북마크 수
를 함께 계산하도록 수정했습니다.
- 상세조회 응답 DTO 생성 시 `liked`, `bookmarked`, `bookmarkCount`를 함께 내려주도록 변경했습니다.

### 3. 북마크 조회용 Repository 메서드 주석 보강
- `BookmarkRepository`의 상세조회 지원용 메서드에 주석을 추가했습니다.
  - `existsByMember_UserIdAndPost_PostId(...)`
  - `countByPost_PostId(...)`
- 어떤 화면/응답을 위해 사용하는 메서드인지 처음 보는 사람도 이해할 수 있도록 설명을 보강했습니다.

### 4. 게시글 상세 링크 경로 수정
- 머지 후 게시글 상세 페이지 경로가 `/post/[postId]`에서 `/posts/[postId]`로 변경되어,
  기존 카드 클릭 시 404가 발생하던 문제를 수정했습니다.
- `frontend/components/post-card.tsx`에서 상세 링크를 `/posts/${post.id}` 기준으로 변경했습니다.


## 🎯 리뷰 포인트
- 상세조회 응답에 북마크 상태/수까지 포함시키는 방식이 현재 구조에 적절한지
- `PostService.findDetailById(...)`에서 북마크 조회를 함께 수행하는 방식이 괜찮은지
- `BookmarkRepository` 메서드 설명이 충분한지
- 게시글 상세 링크를 `/posts/...`로 통일한 방향이 현재 프론트 라우팅 구조와 잘 맞는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?