### PR TITLE
fix : access_token HttpOnly 쿠키 발급으로 로그인 유지 안정화

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/AuthController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/AuthController.java
@@ -8,13 +8,14 @@ import com.back.devc.domain.auth.dto.signup.SignUpResponse;
 import com.back.devc.domain.auth.service.AuthService;
 import com.back.devc.global.response.SuccessCode;
 import com.back.devc.global.response.SuccessResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,30 +24,63 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Value("${custom.jwt.access-cookie-name:access_token}")
+    private String accessCookieName;
+
+    @Value("${custom.jwt.access-cookie-secure:false}")
+    private boolean accessCookieSecure;
+
+    @Value("${custom.jwt.access-cookie-same-site:Lax}")
+    private String accessCookieSameSite;
+
+    @Value("${custom.jwt.access-token-expiration-seconds:3600}")
+    private long accessTokenExpirationSeconds;
+
     @PostMapping("/logout")
-    public ResponseEntity<SuccessResponse<LogoutResponse>> logout() {
-        LogoutResponse response = authService.logout();
+    public ResponseEntity<SuccessResponse<LogoutResponse>> logout(HttpServletResponse response) {
+        LogoutResponse body = authService.logout();
+        setAccessTokenCookie(response, "", 0);
+
         SuccessCode successCode = SuccessCode.LOGOUT_SUCCESS;
         return ResponseEntity
                 .status(successCode.getStatus())
-                .body(SuccessResponse.of(successCode, response));
+                .body(SuccessResponse.of(successCode, body));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<SuccessResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
-        LoginResponse response = authService.login(request);
+    public ResponseEntity<SuccessResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        LoginResponse body = authService.login(request);
+
+        // Bearer + HttpOnly cookie 동시 지원 (프론트 새로고침 안정화)
+        setAccessTokenCookie(response, body.accessToken(), accessTokenExpirationSeconds);
+
         SuccessCode successCode = SuccessCode.LOGIN_SUCCESS;
         return ResponseEntity
                 .status(successCode.getStatus())
-                .body(SuccessResponse.of(successCode, response));
+                .body(SuccessResponse.of(successCode, body));
     }
 
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<SignUpResponse>> signUp(@Valid @RequestBody SignUpRequest request) {
-        SignUpResponse response = authService.signUp(request);
+        SignUpResponse body = authService.signUp(request);
         SuccessCode successCode = SuccessCode.SIGN_UP_SUCCESS;
         return ResponseEntity
                 .status(successCode.getStatus())
-                .body(SuccessResponse.of(successCode, response));
+                .body(SuccessResponse.of(successCode, body));
+    }
+
+    private void setAccessTokenCookie(HttpServletResponse response, String token, long maxAgeSeconds) {
+        ResponseCookie cookie = ResponseCookie.from(accessCookieName, token == null ? "" : token)
+                .httpOnly(true)
+                .secure(accessCookieSecure)
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .sameSite(accessCookieSameSite)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/auth/controller/OAuth2Controller.java
@@ -17,9 +17,13 @@ import com.back.devc.global.response.SuccessResponse;
 import com.back.devc.global.security.jwt.JwtProvider;
 import com.back.devc.global.security.oauth2.OAuth2LoginSuccessHandler;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -40,6 +44,18 @@ public class OAuth2Controller {
     private final OAuthLoginCodeService oAuthLoginCodeService;
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
+
+    @Value("${custom.jwt.access-cookie-name:access_token}")
+    private String accessCookieName;
+
+    @Value("${custom.jwt.access-cookie-secure:false}")
+    private boolean accessCookieSecure;
+
+    @Value("${custom.jwt.access-cookie-same-site:Lax}")
+    private String accessCookieSameSite;
+
+    @Value("${custom.jwt.access-token-expiration-seconds:3600}")
+    private long accessTokenExpirationSeconds;
 
     @GetMapping("/me")
     public OAuth2MeResponse me(
@@ -77,7 +93,8 @@ public class OAuth2Controller {
 
     @PostMapping("/exchange")
     public ResponseEntity<SuccessResponse<LoginResponse>> exchange(
-            @Valid @RequestBody OAuthExchangeRequest request
+            @Valid @RequestBody OAuthExchangeRequest request,
+            HttpServletResponse response
     ) {
         Long userId = oAuthLoginCodeService.consume(request.code())
                 .orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
@@ -90,6 +107,7 @@ public class OAuth2Controller {
         }
 
         String accessToken = jwtProvider.createAccessToken(member);
+        setAccessTokenCookie(response, accessToken, accessTokenExpirationSeconds);
 
         LoginResponse body = new LoginResponse(
                 member.getUserId(),
@@ -109,7 +127,8 @@ public class OAuth2Controller {
     @PostMapping("/signup/complete")
     public ResponseEntity<SuccessResponse<LoginResponse>> completeSignup(
             @Valid @RequestBody OAuthSignupCompleteRequest request,
-            HttpServletRequest httpServletRequest
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse response
     ) {
         HttpSession session = httpServletRequest.getSession(false);
         if (session == null) {
@@ -125,6 +144,7 @@ public class OAuth2Controller {
         session.removeAttribute(OAuth2LoginSuccessHandler.PENDING_SIGNUP_SESSION_KEY);
 
         String accessToken = jwtProvider.createAccessToken(member);
+        setAccessTokenCookie(response, accessToken, accessTokenExpirationSeconds);
 
         LoginResponse body = new LoginResponse(
                 member.getUserId(),
@@ -153,5 +173,17 @@ public class OAuth2Controller {
         }
 
         throw new ApiException(ErrorCode.OAUTH2_UNSUPPORTED_PROVIDER);
+    }
+
+    private void setAccessTokenCookie(HttpServletResponse response, String token, long maxAgeSeconds) {
+        ResponseCookie cookie = ResponseCookie.from(accessCookieName, token == null ? "" : token)
+                .httpOnly(true)
+                .secure(accessCookieSecure)
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .sameSite(accessCookieSameSite)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/member/member/controller/UserController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/member/controller/UserController.java
@@ -8,11 +8,12 @@ import com.back.devc.global.response.SuccessCode;
 import com.back.devc.global.response.SuccessResponse;
 import com.back.devc.global.security.jwt.JwtPrincipal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +26,15 @@ public class UserController {
 
     private final MemberService memberService;
 
-    // 사용자 정보 조회 API
+    @Value("${custom.jwt.access-cookie-name:access_token}")
+    private String accessCookieName;
+
+    @Value("${custom.jwt.access-cookie-secure:false}")
+    private boolean accessCookieSecure;
+
+    @Value("${custom.jwt.access-cookie-same-site:Lax}")
+    private String accessCookieSameSite;
+
     @GetMapping("/me")
     public ResponseEntity<SuccessResponse<MyInfoResponse>> me(
             @AuthenticationPrincipal JwtPrincipal principal
@@ -41,7 +50,6 @@ public class UserController {
                 .body(SuccessResponse.of(successCode, response));
     }
 
-    // 회원 탈퇴 API
     @DeleteMapping("/me")
     public ResponseEntity<SuccessResponse<String>> withdraw(
             @AuthenticationPrincipal JwtPrincipal principal
@@ -50,26 +58,21 @@ public class UserController {
             throw new ApiException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 회원 탈퇴 처리
         memberService.withdraw(principal.userId());
-
-        // 세션 종료
         SecurityContextHolder.clearContext();
 
-        // JWT 토큰 만료 쿠키 삭제
-        ResponseCookie cookie = ResponseCookie.from("access_token", "")
+        ResponseCookie expiredCookie = ResponseCookie.from(accessCookieName, "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(accessCookieSecure)
                 .path("/")
-                .maxAge(0)  // 쿠키 만료
-                .sameSite("Strict")
+                .maxAge(0)
+                .sameSite(accessCookieSameSite)
                 .build();
 
-        // 탈퇴 후 응답 반환
         SuccessCode successCode = SuccessCode.WITHDRAW_SUCCESS;
         return ResponseEntity
                 .status(successCode.getStatus())
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())  // 쿠키 삭제 설정
+                .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
                 .body(SuccessResponse.of(successCode, "회원 탈퇴가 완료되었습니다."));
     }
 }

--- a/back/DevC/src/main/resources/application-dev.yml
+++ b/back/DevC/src/main/resources/application-dev.yml
@@ -48,6 +48,8 @@ custom:
         allowed-origins: http://localhost:3000
 
     jwt:
+        secret-key: "로컬용-충분히-긴-시크릿-문자열"
+        access-token-expiration-seconds: 3600
         access-cookie-name: access_token
         access-cookie-secure: false
         access-cookie-same-site: Lax


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 새로고침 시 로그아웃 안되도록 로그인 상태 유지

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트

새로고침 시 헤더에서 /api/users/me를 Bearer 없이 호출해 401이 났고, 이 401을 로그아웃으로 처리하면서 로컬 토큰을 지우는 게 문제였음. 
-> 로그인 시 액세스 토큰 응답/HttpOnly쿠키 같이 내려서 로그아웃 시 쿠키를 만료시키도록 통이해서 새로고침 이후에도 인증 유지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?