### PR TITLE
feat: 신고 알림 연동 및 게시글/댓글 신고 버튼 추가(#55)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
@@ -19,6 +19,22 @@ public interface NotificationService {
      */
     void createBookmarkNotification(Long postId, Long actorUserId);
 
+    /**
+     * 게시글 신고 알림 생성
+     *
+     * 신고를 누른 사용자가 actorUserId,
+     * 신고된 게시글의 작성자가 알림 수신자가 됨
+     */
+    void createPostReportNotification(Long postId, Long actorUserId);
+
+    /**
+     * 댓글 신고 알림 생성
+     *
+     * 신고를 누른 사용자가 actorUserId,
+     * 신고된 댓글의 작성자가 알림 수신자가 된됨
+     */
+    void createCommentReportNotification(Long commentId, Long actorUserId);
+
     void createReportNotification(Long targetUserId, Long actorUserId, Long postId, String message);
 
     NotificationListResponse getMyNotifications(Long loginUserId);

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
@@ -175,22 +175,93 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     /**
-     * 신고 알림 생성
+     * 게시글 신고 알림 생성
      *
-     * 신고 기능은 게시글 신고/댓글 신고 두 흐름에서 공통으로 사용하므로,
-     * receiver(targetUserId), actor(actorUserId), message를 외부에서 받아 공통 저장만 수행
+     * 주의 사항
+     * - 자기 자신의 게시글을 신고한 경우 알림을 만들지 않음
+     * - 같은 사용자가 같은 게시글을 반복 신고해도 REPORT 알림은 한 번만 남기도록 중복 생성 방지 검사를 수행
      */
     @Override
     @Transactional
-    public void createReportNotification(Long targetUserId, Long actorUserId, Long postId, String message) {
-        if (targetUserId.equals(actorUserId)) {
+    public void createPostReportNotification(Long postId, Long actorUserId) {
+        Long postOwnerId = findPostOwnerId(postId);
+
+        if (postOwnerId.equals(actorUserId)) {
+            return;
+        }
+
+        boolean alreadyNotified = notificationRepository
+                .existsByUserIdAndActorUserIdAndPostIdAndType(postOwnerId, actorUserId, postId, "REPORT");
+
+        if (alreadyNotified) {
             return;
         }
 
         saveNotification(
-                targetUserId,
+                postOwnerId,
                 actorUserId,
                 postId,
+                null,
+                "REPORT",
+                actorUserId + "번 사용자가 회원님의 게시글을 신고했습니다."
+        );
+    }
+
+    /**
+     * 댓글 신고 알림 생성
+     *
+     * 주의 사항
+     * - 자기 자신의 댓글을 신고한 경우 알림을 만들지 않음
+     * - 같은 사용자가 같은 댓글을 반복 신고해도 REPORT 알림은 한 번만 남기도록 중복 생성 방지 검사를 수행
+     */
+    @Override
+    @Transactional
+    public void createCommentReportNotification(Long commentId, Long actorUserId) {
+        Long commentOwnerId = findCommentOwnerId(commentId);
+
+        if (commentOwnerId.equals(actorUserId)) {
+            return;
+        }
+
+        boolean alreadyNotified = notificationRepository.findByUserIdOrderByCreatedAtDesc(commentOwnerId)
+                .stream()
+                .anyMatch(notification ->
+                        "REPORT".equals(notification.getType())
+                                && actorUserId.equals(notification.getActorUserId())
+                                && commentId.equals(notification.getCommentId())
+                );
+
+        if (alreadyNotified) {
+            return;
+        }
+
+        saveNotification(
+                commentOwnerId,
+                actorUserId,
+                null,
+                commentId,
+                "REPORT",
+                actorUserId + "번 사용자가 회원님의 댓글을 신고했습니다."
+        );
+    }
+
+    /**
+     * 기존 NotificationService 인터페이스와의 호환을 위한 공통 신고 알림 생성 메서드.
+     *
+     * 현재 프로젝트에서는 게시글 신고/댓글 신고를 각각 분리해서 사용하고 있지만,
+     * 기존 인터페이스에 남아 있는 createReportNotification(...)도 구현해 두어 컴파일 오류가 나지 않도록 맞춘다.
+     */
+    @Override
+    @Transactional
+    public void createReportNotification(Long targetId, Long actorUserId, Long receiverUserId, String message) {
+        if (receiverUserId.equals(actorUserId)) {
+            return;
+        }
+
+        saveNotification(
+                receiverUserId,
+                actorUserId,
+                null,
                 null,
                 "REPORT",
                 message
@@ -238,6 +309,13 @@ public class NotificationServiceImpl implements NotificationService {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId))
                 .getMember()
+                .getUserId();
+    }
+
+    // 댓글 작성자를 조회해 신고 알림 수신자(receiver)를 구하는 공통 메서드
+    private Long findCommentOwnerId(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId))
                 .getUserId();
     }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/UserReportService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/UserReportService.java
@@ -1,5 +1,6 @@
 package com.back.devc.domain.interaction.report.service;
 
+import com.back.devc.domain.interaction.notification.service.NotificationService;
 import com.back.devc.domain.interaction.report.dto.ReportRequestDTO;
 import com.back.devc.domain.interaction.report.entity.Report;
 import com.back.devc.domain.interaction.report.repository.ReportRepository;
@@ -24,6 +25,8 @@ public class UserReportService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    // 신고 저장 성공 후 대상 작성자에게 신고 알림을 생성하기 위해 사용하는 서비스
+    private final NotificationService notificationService;
 
     public void reportPost(Long reporterId, ReportRequestDTO dto) {
         Member reporter = findMemberOrThrow(reporterId);
@@ -52,6 +55,9 @@ public class UserReportService {
                 .build();
 
         reportRepository.save(report);
+        // 신고 저장이 끝난 뒤 신고된 게시글의 작성자에게 REPORT 알림을 생성
+        // 실제 알림 생성 가능 여부(자기 자신 신고인지, 중복 알림인지 등)는 NotificationService 에서 한 번 더 검증
+        notificationService.createPostReportNotification(dto.getTargetId(), reporterId);
     }
 
     public void reportComment(Long reporterId, ReportRequestDTO dto) {
@@ -81,6 +87,9 @@ public class UserReportService {
                 .build();
 
         reportRepository.save(report);
+        // 신고 저장이 끝난 뒤 신고된 댓글의 작성자에게 REPORT 알림을 생성
+        // 실제 알림 생성 가능 여부(자기 자신 신고인지, 중복 알림인지 등)는 NotificationService 에서 한 번 더 검증
+        notificationService.createCommentReportNotification(dto.getTargetId(), reporterId);
     }
 
     private Member findMemberOrThrow(Long userId) {

--- a/frontend/app/posts/[postId]/page.tsx
+++ b/frontend/app/posts/[postId]/page.tsx
@@ -50,6 +50,7 @@ export default function PostDetailPage() {
   const [bookmarked, setBookmarked] = useState(false)
   const [bookmarkLoading, setBookmarkLoading] = useState(false)
   const [bookmarkCount, setBookmarkCount] = useState(0)
+  const [reportLoading, setReportLoading] = useState(false)
 
   const postId = useMemo(() => {
     const rawPostId = params?.postId
@@ -124,6 +125,42 @@ export default function PostDetailPage() {
       setBookmarkLoading(false)
     }
   }
+
+  const handleReportPost = async () => {
+    if (!postId || Number.isNaN(postId)) {
+      return
+    }
+
+    try {
+      setReportLoading(true)
+      setError(null)
+
+      const response = await fetch(`${API_BASE_URL}/api/report/post`, {
+        method: "POST",
+        headers: {
+          ...getAuthHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          targetId: postId,
+          reasonType: "ETC",
+          reasonDetail: "게시글 상세 페이지에서 접수한 신고입니다.",
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error("게시글 신고에 실패했습니다.")
+      }
+
+      alert("게시글 신고가 접수되었습니다.")
+      window.dispatchEvent(new CustomEvent("notifications-updated"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
+    } finally {
+      setReportLoading(false)
+    }
+  }
+
   const handleToggleLike = async () => {
     if (!postId || Number.isNaN(postId)) {
       return
@@ -213,6 +250,14 @@ export default function PostDetailPage() {
               </button>
               <span className="text-sm text-muted-foreground">북마크 {bookmarkCount}</span>
             </div>
+            <button
+                type="button"
+                onClick={handleReportPost}
+                disabled={reportLoading}
+                className="rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {reportLoading ? "신고 중..." : "신고"}
+            </button>
           </div>
         )}
       </section>

--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -215,6 +215,7 @@ export default function CommentSection({ postId }: CommentSectionProps) {
     const [editingCommentId, setEditingCommentId] = useState<number | null>(null)
     const [editInputs, setEditInputs] = useState<Record<number, string>>({})
     const [editingSubmittingId, setEditingSubmittingId] = useState<number | null>(null)
+    const [reportSubmittingId, setReportSubmittingId] = useState<number | null>(null)
     const [currentUserId, setCurrentUserId] = useState<number | null>(null)
     const [newCommentFiles, setNewCommentFiles] = useState<File[]>([])
     const [replyFiles, setReplyFiles] = useState<ReplyFilesMap>({})
@@ -393,6 +394,35 @@ export default function CommentSection({ postId }: CommentSectionProps) {
         }
     }
 
+    const handleReportComment = async (commentId: number) => {
+        try {
+            setReportSubmittingId(commentId)
+            setError(null)
+
+            const response = await fetch(`http://localhost:8080/api/report/comment`, {
+                ...getAuthFetchOptions(),
+                method: "POST",
+                headers: getJsonAuthHeaders(),
+                body: JSON.stringify({
+                    targetId: commentId,
+                    reasonType: "ETC",
+                    reasonDetail: "댓글 영역에서 접수한 신고입니다.",
+                }),
+            })
+
+            if (!response.ok) {
+                throw new Error("댓글 신고에 실패했습니다.")
+            }
+
+            alert("댓글 신고가 접수되었습니다.")
+            window.dispatchEvent(new CustomEvent("notifications-updated"))
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
+        } finally {
+            setReportSubmittingId(null)
+        }
+    }
+
     const handleDeleteComment = async (commentId: number) => {
         try {
             setDeletingCommentId(commentId)
@@ -564,25 +594,35 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                             <p className="text-xs text-muted-foreground">
                                 작성자: {comment.nickname ?? `user-${comment.userId}`}
                             </p>
-                            {comment.userId === currentUserId && (
-                                <div className="flex items-center gap-3">
-                                    <button
-                                        type="button"
-                                        onClick={() => handleStartEdit(comment.commentId, comment.content)}
-                                        className="text-xs font-medium text-primary hover:underline"
-                                    >
-                                        수정
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => handleDeleteComment(comment.commentId)}
-                                        disabled={deletingCommentId === comment.commentId}
-                                        className="text-xs font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
-                                    >
-                                        {deletingCommentId === comment.commentId ? "삭제 중..." : "삭제"}
-                                    </button>
-                                </div>
-                            )}
+                            <div className="flex items-center gap-3">
+                                {comment.userId === currentUserId && (
+                                    <>
+                                        <button
+                                            type="button"
+                                            onClick={() => handleStartEdit(comment.commentId, comment.content)}
+                                            className="text-xs font-medium text-primary hover:underline"
+                                        >
+                                            수정
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => handleDeleteComment(comment.commentId)}
+                                            disabled={deletingCommentId === comment.commentId}
+                                            className="text-xs font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+                                        >
+                                            {deletingCommentId === comment.commentId ? "삭제 중..." : "삭제"}
+                                        </button>
+                                    </>
+                                )}
+                                <button
+                                    type="button"
+                                    onClick={() => handleReportComment(comment.commentId)}
+                                    disabled={reportSubmittingId === comment.commentId}
+                                    className="text-xs font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    {reportSubmittingId === comment.commentId ? "신고 중..." : "신고"}
+                                </button>
+                            </div>
                         </div>
 
                         <div className="mt-3 flex justify-end">
@@ -701,25 +741,35 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                                             <p className="text-xs text-muted-foreground">
                                                 작성자: {reply.nickname ?? `user-${reply.userId}`}
                                             </p>
-                                            {reply.userId === currentUserId && (
-                                                <div className="flex items-center gap-3">
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => handleStartEdit(reply.commentId, reply.content)}
-                                                        className="text-xs font-medium text-primary hover:underline"
-                                                    >
-                                                        수정
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => handleDeleteComment(reply.commentId)}
-                                                        disabled={deletingCommentId === reply.commentId}
-                                                        className="text-xs font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
-                                                    >
-                                                        {deletingCommentId === reply.commentId ? "삭제 중..." : "삭제"}
-                                                    </button>
-                                                </div>
-                                            )}
+                                            <div className="flex items-center gap-3">
+                                                {reply.userId === currentUserId && (
+                                                    <>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => handleStartEdit(reply.commentId, reply.content)}
+                                                            className="text-xs font-medium text-primary hover:underline"
+                                                        >
+                                                            수정
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => handleDeleteComment(reply.commentId)}
+                                                            disabled={deletingCommentId === reply.commentId}
+                                                            className="text-xs font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+                                                        >
+                                                            {deletingCommentId === reply.commentId ? "삭제 중..." : "삭제"}
+                                                        </button>
+                                                    </>
+                                                )}
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleReportComment(reply.commentId)}
+                                                    disabled={reportSubmittingId === reply.commentId}
+                                                    className="text-xs font-medium text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+                                                >
+                                                    {reportSubmittingId === reply.commentId ? "신고 중..." : "신고"}
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                 ))}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #55 

## 🛠️ 작업 내용
### 1. 신고 알림 서비스 메서드 추가
- `NotificationService`에 신고 알림 생성 메서드를 추가했습니다.
  - `createPostReportNotification(Long postId, Long actorUserId)`
  - `createCommentReportNotification(Long commentId, Long actorUserId)`

### 2. 게시글/댓글 신고 알림 생성 로직 구현
- `NotificationServiceImpl`에 REPORT 알림 생성 로직을 추가했습니다.
- 처리 정책은 다음과 같습니다.
  - 자기 자신의 게시글/댓글을 신고한 경우 알림 생성 제외
  - 같은 사용자가 같은 게시글/댓글을 반복 신고해도 REPORT 알림은 한 번만 생성되도록 중복 방지
- 게시글 신고는 게시글 작성자를 receiver로,
  댓글 신고는 댓글 작성자를 receiver로 설정해 알림을 저장하도록 구현했습니다.

### 3. 신고 저장 후 알림 연동
- `UserReportService`에서 신고 저장 성공 직후 알림 생성 메서드를 호출하도록 수정했습니다.
  - 게시글 신고 저장 후 `createPostReportNotification(...)`
  - 댓글 신고 저장 후 `createCommentReportNotification(...)`
- 실제 알림 생성 가능 여부(자기 자신 신고, 중복 알림 등)는 `NotificationService`에서 한 번 더 검증하도록 분리했습니다.

### 4. 게시글 상세 페이지 신고 버튼 추가
- `frontend/app/posts/[postId]/page.tsx`에 게시글 신고 버튼을 추가했습니다.
- 게시글 상세 페이지에서 `POST /api/report/post` 요청을 보낼 수 있도록 연결했습니다.
- 신고 성공 시 알림 UI 갱신을 위해 `notifications-updated` 이벤트를 발생시키도록 처리했습니다.

### 5. 댓글/대댓글 신고 버튼 추가
- `frontend/components/comment/CommentSection.tsx`에 댓글 및 대댓글 신고 버튼을 추가했습니다.
- `POST /api/report/comment` 요청을 보내도록 연결했습니다.
- 신고 요청 시 `reasonType`, `reasonDetail`을 함께 전달하도록 구현했습니다.
- 신고 중에는 해당 댓글/대댓글 버튼이 `신고 중...` 상태로 표시되도록 처리했습니다.

## 🎯 리뷰 포인트
- 신고 알림을 `NotificationService`에서 생성하도록 분리한 방식이 적절한지
- 자기 자신 신고 및 중복 신고 알림 방지 정책이 현재 서비스 구조와 잘 맞는지
- `UserReportService`에서 저장 후 알림 생성 호출하는 흐름이 자연스러운지
- 게시글/댓글 신고 버튼 UI와 요청 구조가 현재 프론트 흐름에 잘 맞는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="543" height="204" alt="image" src="https://github.com/user-attachments/assets/b6cd885d-3b5a-417e-8532-3d39d5a9c4ed" />
<img width="608" height="645" alt="image" src="https://github.com/user-attachments/assets/ce0ae712-27db-4aff-ba7b-554d361f097b" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?