### PR TITLE
Fix/#112새로고침 후 게시글 작성 오류 해결(#112)

### DIFF
--- a/frontend/app/oauth/callback/page.tsx
+++ b/frontend/app/oauth/callback/page.tsx
@@ -18,38 +18,24 @@ export default function OAuthCallbackPage() {
     const code = searchParams.get("code")
 
     const run = async () => {
-      // ❌ OAuth 실패 케이스
       if (errorCode) {
         router.replace(`/login?oauth=error&errorCode=${errorCode}`)
         return
       }
 
-      // ✅ 핵심: code만 있으면 실행 (🔥 수정된 부분)
       if (code) {
         const usedCodeKey = `oauth_code_used:${code}`
 
-        // 중복 실행 방지
         if (sessionStorage.getItem(usedCodeKey) === "1") {
           return
         }
 
         try {
           const data = await exchangeOAuthCode({ code })
-
-          console.log("🔥 OAuth 최종 데이터:", data)
-
           sessionStorage.setItem(usedCodeKey, "1")
 
-          // 🔥 토큰 저장
-          persistLoginSession(
-            data.accessToken,
-            data.nickname,
-            data.email
-          )
+          persistLoginSession(data.accessToken, data.nickname, data.email)
 
-          console.log("🔥 저장된 토큰:", localStorage.getItem("accessToken"))
-
-          // 이동
           router.replace("/mypage")
           router.refresh()
           return
@@ -60,7 +46,6 @@ export default function OAuthCallbackPage() {
         }
       }
 
-      // ❌ code도 없으면 로그인 페이지
       router.replace("/login")
     }
 

--- a/frontend/app/write/page.tsx
+++ b/frontend/app/write/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select"
 import Link from "next/link"
 import { clearLoginSession, getAuthSnapshot } from "@/lib/auth-storage"
+import { apiFetch } from "@/lib/api"
 
 const categories = [
   { id: 1, name: "IT 기술 정보" },
@@ -23,6 +24,24 @@ const categories = [
   { id: 3, name: "개발자 트렌드" },
   { id: 4, name: "자유 주제" },
 ]
+
+type SuccessResponse<T> = {
+  code?: string
+  message?: string
+  timestamp?: string
+  data?: T
+}
+
+type MyInfoResponse = {
+  userId: number
+  email: string
+  nickname: string
+}
+
+type PostCreateResponse = {
+  postId: number
+  message: string
+}
 
 export default function WritePage() {
   const router = useRouter()
@@ -45,19 +64,17 @@ export default function WritePage() {
 
     const verifyAuth = async () => {
       try {
-        const response = await fetch(`${API_BASE_URL}/api/users/me`, {
+        await apiFetch<SuccessResponse<MyInfoResponse>>("/api/users/me", {
           method: "GET",
-          credentials: "include",
+          auth: true,
           cache: "no-store",
-          headers: getAuthHeaders(),
         })
-
-        if (!response.ok) {
+      } catch (error) {
+        if (error instanceof Error && error.message === "UNAUTHORIZED") {
           clearLoginSession()
           router.replace("/login")
           return
         }
-      } catch {
         // Keep page usable on temporary network issues.
       }
 
@@ -66,25 +83,6 @@ export default function WritePage() {
 
     void verifyAuth()
   }, [router])
-
-
-
-  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
-
-  function getAuthHeaders(): HeadersInit {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    }
-
-    if (typeof window !== "undefined") {
-      const token = window.localStorage.getItem("accessToken")
-      if (token && token !== "oauth-cookie-session") {
-        headers.Authorization = `Bearer ${token}`
-      }
-    }
-
-    return headers
-  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -95,31 +93,16 @@ export default function WritePage() {
     setIsLoading(true)
   
     try {
-      const response = await fetch(`${API_BASE_URL}/api/posts`, {
+      const data = await apiFetch<PostCreateResponse>("/api/posts", {
         method: "POST",
-        credentials: "include",
-        headers: getAuthHeaders(), // 🔥 여기 인증 포함됨
+        auth: true,
         body: JSON.stringify({
           title: formData.title,
           content: formData.content,
-          categoryId: Number(formData.category), // 🔥 핵심 수정
+          categoryId: Number(formData.category),
         }),
       })
-  
-      if (!response.ok) {
-        let message = "게시글 생성 실패"
-        try {
-          const errorBody = await response.json()
-          message = errorBody?.message || errorBody?.data?.message || message
-        } catch {
-          // ignore parse failure
-        }
-        throw new Error(message)
-      }
-  
-      const data = await response.json()
-  
-      // 🔥 postId로 이동
+
       router.push(`/posts/${data.postId}`)
     } catch (err) {
       console.error(err)

--- a/frontend/app/write/page.tsx
+++ b/frontend/app/write/page.tsx
@@ -2,7 +2,19 @@
 
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { ArrowLeft, Save, Eye, ImagePlus, Code, Link2, Bold, Italic, List, ListOrdered, Quote } from "lucide-react"
+import {
+  ArrowLeft,
+  Save,
+  Eye,
+  ImagePlus,
+  Code,
+  Link2,
+  Bold,
+  Italic,
+  List,
+  ListOrdered,
+  Quote,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -16,7 +28,7 @@ import {
 } from "@/components/ui/select"
 import Link from "next/link"
 import { clearLoginSession, getAuthSnapshot } from "@/lib/auth-storage"
-import { apiFetch } from "@/lib/api"
+import { apiFetch, isApiError } from "@/lib/api"
 
 const categories = [
   { id: 1, name: "IT 기술 정보" },
@@ -70,12 +82,12 @@ export default function WritePage() {
           cache: "no-store",
         })
       } catch (error) {
-        if (error instanceof Error && error.message === "UNAUTHORIZED") {
+        if (isApiError(error) && error.isUnauthorized) {
           clearLoginSession()
           router.replace("/login")
           return
         }
-        // Keep page usable on temporary network issues.
+        // 일시적 네트워크 오류면 페이지 사용 허용
       }
 
       setIsAuthReady(true)
@@ -86,12 +98,14 @@ export default function WritePage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+
     if (!formData.category) {
       alert("카테고리를 선택해주세요.")
       return
     }
+
     setIsLoading(true)
-  
+
     try {
       const data = await apiFetch<PostCreateResponse>("/api/posts", {
         method: "POST",
@@ -106,7 +120,11 @@ export default function WritePage() {
       router.push(`/posts/${data.postId}`)
     } catch (err) {
       console.error(err)
-      alert(err instanceof Error ? err.message : "게시글 생성 중 오류가 발생했습니다.")
+      if (isApiError(err)) {
+        alert(err.message)
+      } else {
+        alert("게시글 생성 중 오류가 발생했습니다.")
+      }
     } finally {
       setIsLoading(false)
     }
@@ -152,6 +170,7 @@ export default function WritePage() {
       formData.content.substring(0, start) +
       insertion +
       formData.content.substring(end)
+
     setFormData({ ...formData, content: newContent })
   }
 
@@ -161,7 +180,6 @@ export default function WritePage() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-      {/* Header */}
       <div className="mb-8 flex items-center justify-between">
         <div className="flex items-center gap-4">
           <Link href="/">
@@ -192,7 +210,6 @@ export default function WritePage() {
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
-        {/* Title */}
         <div className="space-y-2">
           <Input
             id="title"
@@ -205,10 +222,11 @@ export default function WritePage() {
           />
         </div>
 
-        {/* Category & Tags */}
         <div className="flex flex-wrap gap-4">
           <div className="w-full sm:w-48">
-            <Label htmlFor="category" className="sr-only">카테고리</Label>
+            <Label htmlFor="category" className="sr-only">
+              카테고리
+            </Label>
             <Select
               value={formData.category}
               onValueChange={(value) => setFormData({ ...formData, category: value })}
@@ -217,16 +235,18 @@ export default function WritePage() {
                 <SelectValue placeholder="카테고리 선택" />
               </SelectTrigger>
               <SelectContent>
-                    {categories.map((category) => (
-                      <SelectItem key={category.id} value={String(category.id)}>
+                {categories.map((category) => (
+                  <SelectItem key={category.id} value={String(category.id)}>
                     {category.name}
-              </SelectItem>
-              ))}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
           <div className="flex-1">
-            <Label htmlFor="tags" className="sr-only">태그</Label>
+            <Label htmlFor="tags" className="sr-only">
+              태그
+            </Label>
             <Input
               id="tags"
               type="text"
@@ -238,7 +258,6 @@ export default function WritePage() {
           </div>
         </div>
 
-        {/* Toolbar */}
         <div className="flex flex-wrap items-center gap-1 rounded-lg border border-border bg-secondary p-2">
           <Button
             type="button"
@@ -316,7 +335,6 @@ export default function WritePage() {
           </Button>
         </div>
 
-        {/* Content */}
         {isPreview ? (
           <div className="min-h-[400px] rounded-lg border border-border bg-card p-6">
             <div className="prose prose-invert max-w-none">
@@ -329,7 +347,9 @@ export default function WritePage() {
           </div>
         ) : (
           <div className="space-y-2">
-            <Label htmlFor="content" className="sr-only">내용</Label>
+            <Label htmlFor="content" className="sr-only">
+              내용
+            </Label>
             <Textarea
               id="content"
               placeholder="내용을 작성하세요. 마크다운 문법을 지원합니다."
@@ -342,7 +362,6 @@ export default function WritePage() {
           </div>
         )}
 
-        {/* Helper Text */}
         <p className="text-xs text-muted-foreground">
           마크다운 문법을 지원합니다. 코드 블록은 ```언어명 으로 시작하세요.
         </p>

--- a/frontend/app/write/page.tsx
+++ b/frontend/app/write/page.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import Link from "next/link"
-import { getAuthSnapshot } from "@/lib/auth-storage"
+import { clearLoginSession, getAuthSnapshot } from "@/lib/auth-storage"
 
 const categories = [
   { id: 1, name: "IT 기술 정보" },
@@ -43,7 +43,28 @@ export default function WritePage() {
       return
     }
 
-    setIsAuthReady(true)
+    const verifyAuth = async () => {
+      try {
+        const response = await fetch(`${API_BASE_URL}/api/users/me`, {
+          method: "GET",
+          credentials: "include",
+          cache: "no-store",
+          headers: getAuthHeaders(),
+        })
+
+        if (!response.ok) {
+          clearLoginSession()
+          router.replace("/login")
+          return
+        }
+      } catch {
+        // Keep page usable on temporary network issues.
+      }
+
+      setIsAuthReady(true)
+    }
+
+    void verifyAuth()
   }, [router])
 
 
@@ -57,7 +78,7 @@ export default function WritePage() {
 
     if (typeof window !== "undefined") {
       const token = window.localStorage.getItem("accessToken")
-      if (token) {
+      if (token && token !== "oauth-cookie-session") {
         headers.Authorization = `Bearer ${token}`
       }
     }
@@ -67,11 +88,16 @@ export default function WritePage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!formData.category) {
+      alert("카테고리를 선택해주세요.")
+      return
+    }
     setIsLoading(true)
   
     try {
       const response = await fetch(`${API_BASE_URL}/api/posts`, {
         method: "POST",
+        credentials: "include",
         headers: getAuthHeaders(), // 🔥 여기 인증 포함됨
         body: JSON.stringify({
           title: formData.title,
@@ -81,7 +107,14 @@ export default function WritePage() {
       })
   
       if (!response.ok) {
-        throw new Error("게시글 생성 실패")
+        let message = "게시글 생성 실패"
+        try {
+          const errorBody = await response.json()
+          message = errorBody?.message || errorBody?.data?.message || message
+        } catch {
+          // ignore parse failure
+        }
+        throw new Error(message)
       }
   
       const data = await response.json()
@@ -90,7 +123,7 @@ export default function WritePage() {
       router.push(`/posts/${data.postId}`)
     } catch (err) {
       console.error(err)
-      alert("게시글 생성 중 오류 발생")
+      alert(err instanceof Error ? err.message : "게시글 생성 중 오류가 발생했습니다.")
     } finally {
       setIsLoading(false)
     }

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -15,6 +15,7 @@ import {
 import {
   AUTH_CHANGED_EVENT,
   clearLoginSession,
+  getAccessToken,
   getAuthSnapshot,
   persistLoginSession,
 } from "@/lib/auth-storage"
@@ -27,22 +28,6 @@ const categories = [
 ]
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
-
-function getAuthHeaders() {
-  if (typeof window === "undefined") {
-    return undefined
-  }
-
-  const token = window.localStorage.getItem("accessToken")
-
-  if (!token || token === "oauth-cookie-session") {
-    return undefined
-  }
-
-  return {
-    Authorization: `Bearer ${token}`,
-  }
-}
 
 type HeaderNotificationItem = {
   notificationId: number
@@ -151,10 +136,15 @@ export function Header() {
         return
       }
       try {
+        const accessToken = getAccessToken()
+        const headers = accessToken
+          ? { Authorization: `Bearer ${accessToken}` }
+          : undefined
+
         const response = await fetch(`${API_BASE_URL}/api/notifications`, {
           cache: "no-store",
           credentials: "include",
-          headers: getAuthHeaders(),
+          headers,
         })
 
         if (!response.ok) {

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -101,7 +101,7 @@ export function Header() {
 
           if (me?.email || me?.nickname) {
             persistLoginSession(
-              "oauth-cookie-session",
+              undefined,
               me?.nickname ?? null,
               me?.email ?? null
             )

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -14,6 +14,32 @@ type RequestOptions = RequestInit & {
   retryOnUnauthorized?: boolean
 }
 
+export class ApiError extends Error {
+  status: number
+  code?: string
+  validation?: Record<string, string>
+
+  constructor(
+    message: string,
+    status: number,
+    options?: { code?: string; validation?: Record<string, string> }
+  ) {
+    super(message)
+    this.name = "ApiError"
+    this.status = status
+    this.code = options?.code
+    this.validation = options?.validation
+  }
+
+  get isUnauthorized() {
+    return this.status === 401
+  }
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError
+}
+
 function isSafeMethod(method?: string) {
   const normalized = (method ?? "GET").toUpperCase()
   return normalized === "GET" || normalized === "HEAD" || normalized === "OPTIONS"
@@ -45,10 +71,7 @@ function buildHeaders(
   return finalHeaders
 }
 
-async function performFetch(
-  path: string,
-  requestInit: RequestInit
-): Promise<Response> {
+async function performFetch(path: string, requestInit: RequestInit): Promise<Response> {
   return fetch(`${API_BASE_URL}${path}`, {
     ...requestInit,
     credentials: "include",
@@ -60,7 +83,7 @@ export async function apiFetch<T>(
   options: RequestOptions = {}
 ): Promise<T> {
   if (!API_BASE_URL) {
-    throw new Error("NEXT_PUBLIC_API_BASE_URL is not set")
+    throw new ApiError("NEXT_PUBLIC_API_BASE_URL is not set", 500)
   }
 
   const {
@@ -84,12 +107,9 @@ export async function apiFetch<T>(
     })
   } catch (error) {
     console.error("FETCH ERROR =", error)
-    throw new Error("백엔드 서버 연결 실패 (CORS/서버실행/주소 확인)")
+    throw new ApiError("백엔드 서버 연결 실패 (CORS/서버실행/주소 확인)", 0)
   }
 
-  // 401 1회 완화 처리:
-  // - 인증 요청(auth=true)인 경우만
-  // - 부작용 없는 메서드(GET/HEAD/OPTIONS)인 경우만 재시도
   if (
     res.status === 401 &&
     auth &&
@@ -100,14 +120,13 @@ export async function apiFetch<T>(
     finalHeaders = buildHeaders(rest, headers, auth, accessToken)
 
     try {
-      const retryRes = await performFetch(path, {
+      res = await performFetch(path, {
         ...rest,
         headers: finalHeaders,
       })
-      res = retryRes
     } catch (error) {
       console.error("RETRY FETCH ERROR =", error)
-      throw new Error("백엔드 서버 연결 실패 (재시도)")
+      throw new ApiError("백엔드 서버 연결 실패 (재시도)", 0)
     }
   }
 
@@ -120,18 +139,19 @@ export async function apiFetch<T>(
     parsed = null
   }
 
-  if (res.status === 401) {
-    throw new Error("UNAUTHORIZED")
-  }
-
   if (!res.ok) {
     const err = parsed as ErrorResponse | null
     const validationMessage = err?.validation
       ? Object.values(err.validation)[0]
       : undefined
 
-    throw new Error(
-      validationMessage || err?.message || `API request failed (${res.status})`
+    throw new ApiError(
+      validationMessage || err?.message || `API request failed (${res.status})`,
+      res.status,
+      {
+        code: err?.code,
+        validation: err?.validation,
+      }
     )
   }
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,3 +1,5 @@
+import { getAccessToken, sanitizeAccessToken } from "./auth-storage"
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 
 type ErrorResponse = {
@@ -11,11 +13,6 @@ type RequestOptions = RequestInit & {
   token?: string | null
 }
 
-function getStoredAccessToken() {
-  if (typeof window === "undefined") return null
-  return localStorage.getItem("accessToken")
-}
-
 export async function apiFetch<T>(
   path: string,
   options: RequestOptions = {}
@@ -25,7 +22,9 @@ export async function apiFetch<T>(
   }
 
   const { auth = false, token, headers, ...rest } = options
-  const accessToken = token ?? getStoredAccessToken()
+  const accessToken = token !== undefined
+    ? sanitizeAccessToken(token)
+    : getAccessToken()
 
   const finalHeaders = new Headers()
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -11,6 +11,48 @@ type ErrorResponse = {
 type RequestOptions = RequestInit & {
   auth?: boolean
   token?: string | null
+  retryOnUnauthorized?: boolean
+}
+
+function isSafeMethod(method?: string) {
+  const normalized = (method ?? "GET").toUpperCase()
+  return normalized === "GET" || normalized === "HEAD" || normalized === "OPTIONS"
+}
+
+function buildHeaders(
+  rest: Omit<RequestInit, "headers">,
+  headers: HeadersInit | undefined,
+  auth: boolean,
+  accessToken: string | null
+): Headers {
+  const finalHeaders = new Headers()
+
+  if (!(rest.body instanceof FormData)) {
+    finalHeaders.set("Content-Type", "application/json")
+  }
+
+  if (headers) {
+    const incoming = new Headers(headers)
+    incoming.forEach((value, key) => {
+      finalHeaders.set(key, value)
+    })
+  }
+
+  if (auth && accessToken) {
+    finalHeaders.set("Authorization", `Bearer ${accessToken}`)
+  }
+
+  return finalHeaders
+}
+
+async function performFetch(
+  path: string,
+  requestInit: RequestInit
+): Promise<Response> {
+  return fetch(`${API_BASE_URL}${path}`, {
+    ...requestInit,
+    credentials: "include",
+  })
 }
 
 export async function apiFetch<T>(
@@ -21,45 +63,57 @@ export async function apiFetch<T>(
     throw new Error("NEXT_PUBLIC_API_BASE_URL is not set")
   }
 
-  const { auth = false, token, headers, ...rest } = options
-  const accessToken = token !== undefined
-    ? sanitizeAccessToken(token)
-    : getAccessToken()
+  const {
+    auth = false,
+    token,
+    headers,
+    retryOnUnauthorized = true,
+    ...rest
+  } = options
 
-  const finalHeaders = new Headers()
+  let accessToken =
+    token !== undefined ? sanitizeAccessToken(token) : getAccessToken()
 
-  if (!(rest.body instanceof FormData)) {
-    finalHeaders.set("Content-Type", "application/json")
-  }
-
-  if (headers) {
-    const incomingHeaders = new Headers(headers)
-    incomingHeaders.forEach((value, key) => {
-      finalHeaders.set(key, value)
-    })
-  }
-
-  if (auth && accessToken) {
-    finalHeaders.set("Authorization", `Bearer ${accessToken}`)
-  }
+  let finalHeaders = buildHeaders(rest, headers, auth, accessToken)
 
   let res: Response
-
   try {
-    res = await fetch(`${API_BASE_URL}${path}`, {
+    res = await performFetch(path, {
       ...rest,
       headers: finalHeaders,
-      credentials: "include",
     })
   } catch (error) {
     console.error("FETCH ERROR =", error)
     throw new Error("백엔드 서버 연결 실패 (CORS/서버실행/주소 확인)")
   }
 
+  // 401 1회 완화 처리:
+  // - 인증 요청(auth=true)인 경우만
+  // - 부작용 없는 메서드(GET/HEAD/OPTIONS)인 경우만 재시도
+  if (
+    res.status === 401 &&
+    auth &&
+    retryOnUnauthorized &&
+    isSafeMethod(rest.method)
+  ) {
+    accessToken = getAccessToken()
+    finalHeaders = buildHeaders(rest, headers, auth, accessToken)
+
+    try {
+      const retryRes = await performFetch(path, {
+        ...rest,
+        headers: finalHeaders,
+      })
+      res = retryRes
+    } catch (error) {
+      console.error("RETRY FETCH ERROR =", error)
+      throw new Error("백엔드 서버 연결 실패 (재시도)")
+    }
+  }
+
   const text = await res.text()
 
   let parsed: T | ErrorResponse | null = null
-
   try {
     parsed = text ? (JSON.parse(text) as T | ErrorResponse) : null
   } catch {

--- a/frontend/lib/auth-storage.ts
+++ b/frontend/lib/auth-storage.ts
@@ -49,7 +49,8 @@ export function getAuthSnapshot(): AuthSnapshot {
     token,
     nickname,
     email,
-    isLoggedIn: Boolean(token || email),
+    // 핵심 변경: 이메일 존재 여부가 아니라 "유효한 토큰 존재"로 로그인 판정
+    isLoggedIn: Boolean(token),
   }
 }
 
@@ -87,7 +88,7 @@ function writeProfileMap(profileMap: UserProfileMap) {
 /**
  * accessToken:
  * - string 전달: 그 값으로 갱신
- * - null 전달: 토큰 삭제
+ * - null 전달: 토큰 제거
  * - undefined 전달: 기존 토큰 유지
  */
 export function persistLoginSession(

--- a/frontend/lib/auth-storage.ts
+++ b/frontend/lib/auth-storage.ts
@@ -3,6 +3,7 @@ export const AUTH_NICKNAME_KEY = "nickname"
 export const AUTH_EMAIL_KEY = "email"
 export const AUTH_CHANGED_EVENT = "auth-changed"
 export const AUTH_PROFILES_KEY = "userProfiles"
+export const OAUTH_COOKIE_SESSION_TOKEN = "oauth-cookie-session"
 
 export type AuthSnapshot = {
   token: string | null
@@ -24,12 +25,23 @@ export type UserProfile = {
 
 type UserProfileMap = Record<string, UserProfile>
 
+export function sanitizeAccessToken(token: string | null | undefined): string | null {
+  if (!token) return null
+
+  const trimmedToken = token.trim()
+  if (!trimmedToken || trimmedToken === OAUTH_COOKIE_SESSION_TOKEN) {
+    return null
+  }
+
+  return trimmedToken
+}
+
 export function getAuthSnapshot(): AuthSnapshot {
   if (typeof window === "undefined") {
     return { token: null, nickname: null, email: null, isLoggedIn: false }
   }
 
-  const token = localStorage.getItem(AUTH_TOKEN_KEY)
+  const token = sanitizeAccessToken(localStorage.getItem(AUTH_TOKEN_KEY))
   const nickname = localStorage.getItem(AUTH_NICKNAME_KEY)
   const email = localStorage.getItem(AUTH_EMAIL_KEY)
 
@@ -46,7 +58,7 @@ export function getAccessToken(): string | null {
     return null
   }
 
-  return localStorage.getItem(AUTH_TOKEN_KEY)
+  return sanitizeAccessToken(localStorage.getItem(AUTH_TOKEN_KEY))
 }
 
 function notifyAuthChanged() {
@@ -86,10 +98,15 @@ export function persistLoginSession(
   if (typeof window === "undefined") return
 
   if (accessToken !== undefined) {
-    if (accessToken && accessToken.trim().length > 0) {
-      localStorage.setItem(AUTH_TOKEN_KEY, accessToken)
+    if (accessToken === OAUTH_COOKIE_SESSION_TOKEN) {
+      // Placeholder value must not overwrite or clear an existing access token.
     } else {
-      localStorage.removeItem(AUTH_TOKEN_KEY)
+      const normalizedToken = sanitizeAccessToken(accessToken)
+      if (normalizedToken) {
+        localStorage.setItem(AUTH_TOKEN_KEY, normalizedToken)
+      } else {
+        localStorage.removeItem(AUTH_TOKEN_KEY)
+      }
     }
   }
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,5 +1,4 @@
 import { apiFetch } from "./api"
-import { persistLoginSession } from "./auth-storage"
 
 type SuccessResponse<T> = {
   code: string
@@ -50,23 +49,7 @@ export async function login(body: LoginRequest): Promise<LoginData> {
     body: JSON.stringify(body),
   })
 
-  const data = res.data
-
-  // 🔥 디버깅 (이거 꼭 확인)
-  console.log("🔥 login data:", data)
-  console.log("🔥 accessToken:", data.accessToken)
-
-  // 🔥 토큰 저장
-  persistLoginSession(
-    data.accessToken,
-    data.nickname,
-    data.email
-  )
-
-  // 🔥 저장 확인
-  console.log("🔥 저장된 토큰:", localStorage.getItem("accessToken"))
-
-  return data
+  return res.data
 }
 
 export async function signup(body: SignUpRequest): Promise<SignUpData> {
@@ -89,17 +72,7 @@ export async function exchangeOAuthCode(
     }
   )
 
-  const data = res.data
-
-  console.log("🔥 oauth login data:", data)
-
-  persistLoginSession(
-    data.accessToken,
-    data.nickname,
-    data.email
-  )
-
-  return data
+  return res.data
 }
 
 export async function completeOAuthSignup(
@@ -114,15 +87,5 @@ export async function completeOAuthSignup(
     }
   )
 
-  const data = res.data
-
-  console.log("🔥 oauth signup complete:", data)
-
-  persistLoginSession(
-    data.accessToken,
-    data.nickname,
-    data.email
-  )
-
-  return data
+  return res.data
 }


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #112

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 새로고침 반복 후 글쓰기 저장 시 인증 실패 발생 문제 수정
- [x] 인증 토큰 처리 공통화 및 write/header 인증 흐름 정리
- [x] 인증 토큰 처리 공통화 및 로그인/인증 흐름 정리
- [x]  인증 상태 단일 소스 강화: useAuth() 훅에서 isLoggedIn 판단 + /api/users/me 동기화 흐름 통합
- [x] 토큰 정규화/방어 처리: oauth-cookie-session 등 임시값/오염값을 인증 토큰으로 사용하지 않도록 공통 처리
- [x] 하이드레이션 불일치 방지: 초기 렌더 시 서버/클라이언트 인증 상태 차이로 발생하던 UI 미스매칭 완화

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트

**1. 변경 전**

- 인증 토큰 처리 규칙이 화면/모듈별로 분산되어 있었음.
- localStorage에서 토큰을 각 파일이 직접 읽고, 각자 Authorization 헤더를 구성함.
- oauth-cookie-session 같은 임시값 처리 규칙이 통일되지 않아 인증 상태 불일치
- /write 페이지에서 인증 검증과 게시글 저장 로직이 페이지 내부 fetch 구현에 의존.
- 로그인/OAuth 처리 코드에 세션 저장 로직과 디버그 로그가 중복되어 유지보수가 어려움.
- OAuth 콜백 흐름에서 중복 저장/불필요한 로그로 동작 경로가 복잡했음.
- 새로고침 후 localStorage 복원 시점과 화면별 인증 체크 시점이 달라 로그인 상태 불일치가 발생
- 일부 화면에서 토큰을 직접 읽어 Authorization 헤더를 구성하면서 공통 규칙 불일치
- 임시 세션 문자열이 토큰처럼 취급되어 API 401 및 게시글 작성 실패

**2. 변경 후**
- 인증 토큰 정책을 공통 모듈 중심으로 통일함.
- API 인증 경로를 apiFetch(auth: true)로 공통화함.
- /write 페이지 인증 흐름 정리
- header에서 중복된 인증 헤더 생성 제거
- 로그인/OAuth 코드 정리
- OAuth 콜백 처리 단순화


**3. 파일별 수정 내용**
- **/lib/api.ts** : apiFetch 공통 함수로 API 호출을 통일. `auth: true` 옵션일 때 토큰을 읽어 Authorization 헤더를 붙이고, credentials: "include"를 기본 적용하도록 정리.
- **/lib/auth-storage.ts** : 로그인 세션 저장/조회/삭제를 공통화. getAuthSnapshot, persistLoginSession, clearLoginSession, AUTH_CHANGED_EVENT를 통해 화면별로 흩어진 인증 상태 관리를 한 곳으로 모음.
- **/lib/auth.ts** : 로그인/회원가입/OAuth 교환 API를 모듈화. 로그인 성공 시 세션 저장 로직(persistLoginSession)을 공통 함수에서 처리하도록 정리.
- **/app/login/page.tsx** : 로그인 성공 후 토큰/유저정보 저장 흐름을 공통 저장 함수 기반으로 맞춤. OAuth 에러코드 처리 및 소셜 로그인 진입 흐름 정리.
- **/app/oauth/callback/page.tsx** : OAuth code 교환 처리와 중복 실행 방지(sessionStorage used key) 추가. 교환 성공 시 세션 저장 후 라우팅하도록 정리.
- **/components/layout/header.tsx** : 헤더에서 인증 상태를 getAuthSnapshot + /api/users/me 동기화로 갱신하도록 변경. 알림/글쓰기/마이페이지 링크를 로그인 상태 기반으로 일관 처리.
- **/app/write/page.tsx** : 진입 시 인증 상태 확인 후 비로그인 리다이렉트. 게시글 저장 시 인증 헤더 포함 요청으로 정리해 새로고침 이후에도 작성 흐름이 이어지게 수정.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?