### PR TITLE
fix: 댓글 작성자와 로그인 사용자 상태 동기화 개선

### DIFF
--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -100,7 +100,7 @@ function getAuthFetchOptions(): Pick<RequestInit, "credentials" | "headers"> {
     }
 }
 
-function getCurrentUserId(): number | null {
+function getCurrentUserIdFromToken(): number | null {
     if (typeof window === "undefined") {
         return null
     }
@@ -120,6 +120,47 @@ function getCurrentUserId(): number | null {
         }
 
         const rawUserId = decoded.userId ?? decoded.user_id ?? decoded.id ?? decoded.sub
+
+        if (typeof rawUserId === "number") {
+            return rawUserId
+        }
+
+        if (typeof rawUserId === "string") {
+            const parsedUserId = Number(rawUserId)
+            return Number.isNaN(parsedUserId) ? null : parsedUserId
+        }
+
+        return null
+    } catch {
+        return null
+    }
+}
+
+/**
+ * OAuth 로그인 사용자는 localStorage 기반 JWT가 없을 수 있어서,
+ * 쿠키 인증으로 현재 사용자 정보를 다시 조회해 currentUserId 를 동기화한다.
+ */
+async function fetchCurrentUserIdFromServer(): Promise<number | null> {
+    try {
+        const response = await fetch("http://localhost:8080/api/users/me", {
+            ...getAuthFetchOptions(),
+            method: "GET",
+        })
+
+        if (!response.ok) {
+            return null
+        }
+
+        const data = (await response.json()) as {
+            userId?: number | string
+            id?: number | string
+            data?: {
+                userId?: number | string
+                id?: number | string
+            }
+        }
+
+        const rawUserId = data.userId ?? data.id ?? data.data?.userId ?? data.data?.id
 
         if (typeof rawUserId === "number") {
             return rawUserId
@@ -245,21 +286,44 @@ export default function CommentSection({ postId }: CommentSectionProps) {
     }, [loadComments])
 
     useEffect(() => {
+        let cancelled = false
+
         const syncCurrentUserId = () => {
-            setCurrentUserId(getCurrentUserId())
+            void (async () => {
+                const tokenUserId = getCurrentUserIdFromToken()
+
+                if (tokenUserId !== null) {
+                    if (!cancelled) {
+                        setCurrentUserId(tokenUserId)
+                    }
+                    return
+                }
+
+                const serverUserId = await fetchCurrentUserIdFromServer()
+                if (!cancelled) {
+                    setCurrentUserId(serverUserId)
+                }
+            })()
+        }
+
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === "visible") {
+                syncCurrentUserId()
+            }
         }
 
         syncCurrentUserId()
 
         window.addEventListener("storage", syncCurrentUserId)
         window.addEventListener("focus", syncCurrentUserId)
-        document.addEventListener("visibilitychange", syncCurrentUserId)
+        document.addEventListener("visibilitychange", handleVisibilityChange)
         window.addEventListener("auth-changed", syncCurrentUserId as EventListener)
 
         return () => {
+            cancelled = true
             window.removeEventListener("storage", syncCurrentUserId)
             window.removeEventListener("focus", syncCurrentUserId)
-            document.removeEventListener("visibilitychange", syncCurrentUserId)
+            document.removeEventListener("visibilitychange", handleVisibilityChange)
             window.removeEventListener("auth-changed", syncCurrentUserId as EventListener)
         }
     }, [])


### PR DESCRIPTION
## 📌 관련 이슈

Closes #110 

## 🛠️ 작업 내용
### 1. 댓글 컴포넌트의 현재 로그인 사용자 동기화 방식 개선

기존에는 댓글 컴포넌트에서 현재 로그인 사용자 식별값(`currentUserId`)을

로컬 토큰 기준으로만 판단하고 있어, 로그인 직후나 OAuth 로그인 환경에서

본인 댓글임에도 수정/삭제 버튼이 바로 표시되지 않는 문제가 있었습니다.

이를 다음과 같이 수정했습니다.

- 토큰이 있는 경우 JWT payload에서 `currentUserId` 추출

- 토큰이 없는 경우 `/api/users/me`를 쿠키 인증으로 조회하여 현재 사용자 id 동기화

- 댓글 컴포넌트 진입 시 현재 사용자 정보 재동기화

- `storage`, `focus`, `visibilitychange`, `auth-changed` 이벤트 발생 시 다시 동기화되도록 보완

### 2. OAuth 로그인 환경 대응

OAuth 로그인 사용자는 localStorage 기반 JWT가 없을 수 있어

기존 방식으로는 `currentUserId`를 안정적으로 세팅하기 어려웠습니다.

이를 보완하기 위해:

- 쿠키 인증 기반 현재 사용자 조회 로직 추가

- OAuth 로그인 상태에서도 댓글 작성자 본인 여부가 동일하게 판단되도록 수정

### 3. 댓글 수정/삭제 버튼 표시 안정화

현재 로그인 사용자 상태와 댓글 작성자 정보 비교가 더 안정적으로 이루어지도록 정리하여,

다음 상황에서도 수정/삭제 버튼이 일관되게 표시되도록 개선했습니다.

- 댓글 작성 직후

- 페이지 재진입 시

- 로그아웃 후 재로그인 시

- 일반 로그인 / OAuth 로그인 환경 모두

## 🎯 리뷰 포인트
- `currentUserId`를 토큰 우선, 서버 조회 보조 방식으로 동기화한 방향이 적절한지

- 댓글 컴포넌트에서 이벤트 기반 재동기화(`storage`, `focus`, `visibilitychange`, `auth-changed`)를 적용한 방식이 적절한지

- OAuth 로그인 사용자의 현재 사용자 상태 반영 방식이 현재 인증 구조와 잘 맞는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?