### PR TITLE
feat: 알림 발신자 표시를 닉네임 기준으로 변경

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/dto/NotificationResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/dto/NotificationResponse.java
@@ -7,6 +7,7 @@ public class NotificationResponse {
     private final Long notificationId;
     private final Long userId;
     private final Long actorUserId;
+    private final String actorNickname;
     private final Long postId;
     private final Long commentId;
     private final String type;
@@ -18,6 +19,7 @@ public class NotificationResponse {
             Long notificationId,
             Long userId,
             Long actorUserId,
+            String actorNickname,
             Long postId,
             Long commentId,
             String type,
@@ -28,6 +30,7 @@ public class NotificationResponse {
         this.notificationId = notificationId;
         this.userId = userId;
         this.actorUserId = actorUserId;
+        this.actorNickname = actorNickname;
         this.postId = postId;
         this.commentId = commentId;
         this.type = type;
@@ -46,6 +49,10 @@ public class NotificationResponse {
 
     public Long getActorUserId() {
         return actorUserId;
+    }
+
+    public String getActorNickname() {
+        return actorNickname;
     }
 
     public Long getPostId() {

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationServiceImpl.java
@@ -7,6 +7,7 @@ import com.back.devc.domain.interaction.notification.repository.NotificationRepo
 import com.back.devc.domain.post.comment.entity.Comment;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
 import com.back.devc.domain.post.post.repository.PostRepository;
+import com.back.devc.domain.member.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,6 +42,8 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationRepository notificationRepository;
     // 답글 알림 생성 시 부모 댓글 상태(존재 여부, 삭제 여부, 작성자)를 확인할 때 사용
     private final CommentRepository commentRepository;
+    // actorUserId로 회원 닉네임을 조회해 알림 메시지/응답에 사용
+    private final MemberRepository memberRepository;
     // 게시글 작성자(userId)를 찾아 "알림 수신자"를 결정할 때 사용
     private final PostRepository postRepository;
 
@@ -61,13 +64,15 @@ public class NotificationServiceImpl implements NotificationService {
             return;
         }
 
+        String actorNickname = findMemberNickname(actorUserId);
+
         saveNotification(
                 postOwnerId,
                 actorUserId,
                 postId,
                 commentId,
                 "COMMENT",
-                actorUserId + "번 사용자가 게시글에 댓글을 남겼습니다."
+                actorNickname + "님이 게시글에 댓글을 남겼습니다."
         );
     }
 
@@ -96,13 +101,15 @@ public class NotificationServiceImpl implements NotificationService {
             return;
         }
 
+        String actorNickname = findMemberNickname(actorUserId);
+
         saveNotification(
                 receiverUserId,
                 actorUserId,
                 parentComment.getPostId(),
                 replyCommentId,
                 "REPLY",
-                actorUserId + "번 사용자가 회원님의 댓글에 답글을 남겼습니다."
+                actorNickname + "님이 회원님의 댓글에 답글을 남겼습니다."
         );
     }
 
@@ -130,13 +137,15 @@ public class NotificationServiceImpl implements NotificationService {
             return;
         }
 
+        String actorNickname = findMemberNickname(actorUserId);
+
         saveNotification(
                 postOwnerId,
                 actorUserId,
                 postId,
                 null,
                 "LIKE",
-                actorUserId + "번 사용자가 회원님의 게시글을 좋아합니다."
+                actorNickname + "님이 회원님의 게시글을 좋아합니다."
         );
     }
 
@@ -164,13 +173,15 @@ public class NotificationServiceImpl implements NotificationService {
             return;
         }
 
+        String actorNickname = findMemberNickname(actorUserId);
+
         saveNotification(
                 postOwnerId,
                 actorUserId,
                 postId,
                 null,
                 "BOOKMARK",
-                actorUserId + "번 사용자가 회원님의 게시글을 북마크했습니다."
+                actorNickname + "님이 회원님의 게시글을 북마크했습니다."
         );
     }
 
@@ -356,12 +367,24 @@ public class NotificationServiceImpl implements NotificationService {
         notificationRepository.save(notification);
     }
 
+    // actorUserId로 회원 닉네임을 조회하는 공통 메서드
+    private String findMemberNickname(Long userId) {
+        return memberRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. id=" + userId))
+                .getNickname();
+    }
+
     // Entity -> Response DTO 변환 메서드
     private NotificationResponse toResponse(Notification notification) {
+        String actorNickname = notification.getActorUserId() != null
+                ? findMemberNickname(notification.getActorUserId())
+                : null;
+
         return new NotificationResponse(
                 notification.getId(),
                 notification.getUserId(),
                 notification.getActorUserId(),
+                actorNickname,
                 notification.getPostId(),
                 notification.getCommentId(),
                 notification.getType(),

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -17,6 +17,7 @@ type NotificationItem = {
   notificationId: number
   userId: number
   actorUserId: number
+  actorNickname?: string
   postId: number | null
   commentId: number | null
   type: string
@@ -412,9 +413,12 @@ export default function NotificationsPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex items-start gap-2">
                         <Avatar className="h-6 w-6">
-                          <AvatarImage src={undefined} alt={`${notification.actorUserId}번 사용자`} />
+                          <AvatarImage
+                            src={undefined}
+                            alt={notification.actorNickname ?? `${notification.actorUserId}번 사용자`}
+                          />
                           <AvatarFallback className="bg-secondary text-xs text-secondary-foreground">
-                            U{notification.actorUserId}
+                            {notification.actorNickname?.trim()?.slice(0, 2) || `U${notification.actorUserId}`}
                           </AvatarFallback>
                         </Avatar>
                         <div className="flex-1">
@@ -424,7 +428,7 @@ export default function NotificationsPage() {
                               href={`/posts/${notification.postId}`}
                               className="mt-1 line-clamp-1 text-sm text-primary hover:underline"
                             >
-                              게시글 {notification.postId}번으로 이동
+                              게시글로 이동
                             </Link>
                           ) : null}
                           <p className="mt-1 text-xs text-muted-foreground">


### PR DESCRIPTION
## 📌 관련 이슈

Closes #117 

## 🛠️ 작업 내용
### 1. 알림 메시지 발신자 표시를 userId → 닉네임으로 변경

기존에는 댓글/답글/좋아요/북마크 알림 메시지에 발신자 정보가

`4번 사용자`처럼 userId 기반으로 표시되고 있었습니다.

이를 다음과 같이 변경했습니다.

- `NotificationServiceImpl`에서 `actorUserId`로 회원 닉네임 조회

- 댓글 / 답글 / 좋아요 / 북마크 알림 메시지 생성 시 닉네임 기반으로 저장

- 예시:

  - 기존: `4번 사용자가 회원님의 게시글을 좋아합니다.`

  - 변경: `ktj1903님이 회원님의 게시글을 좋아합니다.`

### 2. 알림 응답 DTO에 발신자 닉네임 필드 추가

프론트에서도 닉네임을 직접 사용할 수 있도록

`NotificationResponse`에 `actorNickname` 필드를 추가했습니다.

적용 내용:

- `actorUserId`와 함께 `actorNickname` 응답 제공

- 알림 목록 UI에서 닉네임 기반 표시 가능하도록 응답 구조 확장

### 3. 알림 목록 UI 표시 개선

알림 페이지에서 아바타 fallback이 기존 `U4`처럼

userId 기반으로 보이던 부분을 닉네임 우선 표시로 변경했습니다.

적용 내용:

- `actorNickname`이 존재하면 닉네임 앞 2글자를 fallback으로 표시

- 닉네임이 없을 경우에만 기존 `U{actorUserId}` 방식으로 fallback

- 알림 링크 문구도 `게시글 1번으로 이동` → `게시글로 이동`으로 정리

## 🎯 리뷰 포인트
- `actorUserId` 기반 메시지를 닉네임 기반으로 변경한 방식이 적절한지

- `NotificationResponse`에 `actorNickname` 필드를 추가한 구조가 현재 응답 설계와 잘 맞는지

- 프론트 알림 목록에서 닉네임 fallback 처리 방식이 적절한지

- 알림 표시 가독성 개선 방향이 서비스 UX와 잘 맞는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="514" height="351" alt="image" src="https://github.com/user-attachments/assets/9bf4b0aa-6ac1-4dc2-ae81-fc142a7ee9de" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?