### PR TITLE
refactor/#142 내 정보 수정 시 이메일은 안되게 구현

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/member/member/entity/Member.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/member/entity/Member.java
@@ -128,10 +128,6 @@ public class Member {
         );
     }
 
-    public void updateEmail(String email) {
-        this.email = email;
-    }
-
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
@@ -195,5 +191,4 @@ public class Member {
     public void setSuspendedUntil(LocalDateTime suspendedUntil) {
         this.suspendedUntil = suspendedUntil;
     }
-
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/member/mypage/controller/MypageController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/mypage/controller/MypageController.java
@@ -2,7 +2,7 @@ package com.back.devc.domain.member.mypage.controller;
 
 import com.back.devc.domain.interaction.bookmark.dto.BookmarkedPostResponse;
 import com.back.devc.domain.interaction.postLike.dto.LikedPostResponse;
-import com.back.devc.domain.member.mypage.dto.MyCommentResponse;
+import com.back.devc.domain.member.mypage.dto.MyCommentsResponse;
 import com.back.devc.domain.member.mypage.dto.MyPostResponse;
 import com.back.devc.domain.member.mypage.dto.MyProfileResponse;
 import com.back.devc.domain.member.mypage.dto.UpdateMyProfileRequest;
@@ -41,11 +41,11 @@ public class MypageController {
     }
 
     @GetMapping("/comments")
-    public List<MyCommentResponse> getMyComments(
+    public MyCommentsResponse getMyComments(
             @AuthenticationPrincipal JwtPrincipal principal
     ) {
         validatePrincipal(principal);
-        return mypageService.getMyComments(principal.userId());
+        return new MyCommentsResponse(mypageService.getMyComments(principal.userId()));
     }
 
     @GetMapping("/likes")

--- a/back/DevC/src/main/java/com/back/devc/domain/member/mypage/dto/MyCommentResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/mypage/dto/MyCommentResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public record MyCommentResponse(
         Long commentId,
         Long postId,
+        String postTitle,
         String content,
         LocalDateTime createdAt
 ) {

--- a/back/DevC/src/main/java/com/back/devc/domain/member/mypage/dto/MyCommentsResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/mypage/dto/MyCommentsResponse.java
@@ -1,0 +1,8 @@
+package com.back.devc.domain.member.mypage.dto;
+
+import java.util.List;
+
+public record MyCommentsResponse(
+        List<MyCommentResponse> comments
+) {
+}

--- a/back/DevC/src/main/java/com/back/devc/domain/member/mypage/dto/UpdateMyProfileRequest.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/mypage/dto/UpdateMyProfileRequest.java
@@ -1,14 +1,9 @@
 package com.back.devc.domain.member.mypage.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateMyProfileRequest(
-
-        @NotBlank(message = "이메일은 필수입니다.")
-        @Email(message = "올바른 이메일 형식이어야 합니다.")
-        String email,
 
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")

--- a/back/DevC/src/main/java/com/back/devc/domain/member/mypage/service/MypageService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/mypage/service/MypageService.java
@@ -67,12 +67,18 @@ public class MypageService {
         List<Comment> comments = commentRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(userId);
 
         return comments.stream()
-                .map(comment -> new MyCommentResponse(
-                        comment.getId(),
-                        comment.getPostId(),
-                        comment.getContent(),
-                        comment.getCreatedAt()
-                ))
+                .map(comment -> {
+                    Post post = postRepository.findById(comment.getPostId())
+                            .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + comment.getPostId()));
+
+                    return new MyCommentResponse(
+                            comment.getId(),
+                            comment.getPostId(),
+                            post.getTitle(),
+                            comment.getContent(),
+                            comment.getCreatedAt()
+                    );
+                })
                 .toList();
     }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/member/mypage/service/MypageService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/member/mypage/service/MypageService.java
@@ -101,18 +101,12 @@ public class MypageService {
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. id=" + userId));
 
-        String newEmail = request.email().trim();
         String newNickname = request.nickname().trim();
-
-        if (!member.getEmail().equals(newEmail) && memberRepository.existsByEmail(newEmail)) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
-        }
 
         if (!member.getNickname().equals(newNickname) && memberRepository.existsByNickname(newNickname)) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        member.updateEmail(newEmail);
         member.updateNickname(newNickname);
 
         return new MyProfileResponse(

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
@@ -1,7 +1,6 @@
 package com.back.devc.domain.post.comment.dto;
 
 import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentResponse;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +16,7 @@ public class CommentResponse {
 
     private Long commentId;
     private Long postId;
+    private String postTitle;
     private Long userId;
     private String nickname;
     private Long parentCommentId;
@@ -30,6 +30,7 @@ public class CommentResponse {
     public static CommentResponse of(
             Long commentId,
             Long postId,
+            String postTitle,
             Long userId,
             String nickname,
             Long parentCommentId,
@@ -41,6 +42,7 @@ public class CommentResponse {
         return CommentResponse.builder()
                 .commentId(commentId)
                 .postId(postId)
+                .postTitle(postTitle)
                 .userId(userId)
                 .nickname(nickname)
                 .parentCommentId(parentCommentId)

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentServiceImpl.java
@@ -12,6 +12,7 @@ import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.dto.CommentUpdateRequest;
 import com.back.devc.domain.post.comment.entity.Comment;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
+import com.back.devc.domain.post.post.entity.Post;
 import com.back.devc.domain.post.post.repository.PostRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -170,9 +171,13 @@ public class CommentServiceImpl implements CommentService {
     }
 
     private CommentResponse toResponse(Comment comment, Member member) {
+        Post post = postRepository.findById(comment.getPostId())
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + comment.getPostId()));
+
         CommentResponse response = CommentResponse.of(
                 comment.getId(),
                 comment.getPostId(),
+                post.getTitle(),
                 comment.getUserId(),
                 MemberDisplayUtil.getDisplayName(member),
                 comment.getParentCommentId(),

--- a/back/DevC/src/main/resources/application-dev.yml
+++ b/back/DevC/src/main/resources/application-dev.yml
@@ -10,8 +10,8 @@ spring:
       client:
         registration:
           github:
-            client-id: ${GITHUB_CLIENT_ID}
-            client-secret: ${GITHUB_CLIENT_SECRET}
+            client-id: "Ov23liq1Y34Z0DSnB94l" # 환경 변수
+            client-secret: "d765efc1f98cdbcd3af38a97b97fe215812a8e7c"
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
           kakao:
             client-id: ${KAKAO_CLIENT_ID}

--- a/back/DevC/src/main/resources/application-dev.yml
+++ b/back/DevC/src/main/resources/application-dev.yml
@@ -11,8 +11,8 @@ spring:
         registration:
           github:
             client-id: "Ov23liq1Y34Z0DSnB94l" # 환경 변수
-            client-secret: "d765efc1f98cdbcd3af38a97b97fe215812a8e7c"
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}

--- a/back/DevC/src/main/resources/application-dev.yml
+++ b/back/DevC/src/main/resources/application-dev.yml
@@ -9,10 +9,10 @@ spring:
     oauth2:
       client:
         registration:
-          github:
-            client-id: "Ov23liq1Y34Z0DSnB94l" # 환경 변수
+          github: # 환경 변수
             client-id: ${GITHUB_CLIENT_ID}
             client-secret: ${GITHUB_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}

--- a/frontend/app/feed/page.tsx
+++ b/frontend/app/feed/page.tsx
@@ -1,206 +1,232 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
 import { PostCard, type Post } from "@/components/post-card"
-import { Users, UserPlus, Search } from "lucide-react"
+import { Bookmark, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { apiFetch } from "@/lib/api"
+import { getAuthSnapshot } from "@/lib/auth-storage"
 import Link from "next/link"
 
-// Mock followed users
-const followedUsers = [
-  { id: "1", name: "김개발", avatar: "", bio: "10년차 풀스택 개발자" },
-  { id: "2", name: "박취준", avatar: "", bio: "취업/이직 전문가" },
-  { id: "3", name: "이트렌드", avatar: "", bio: "IT 트렌드 분석가" },
-]
+type BookmarkedPostResponse = {
+  postId: number
+  title: string
+  authorNickname: string
+  likeCount: number
+  commentCount: number
+  createdAt: string
+}
 
-// Mock suggested users
-const suggestedUsers = [
-  { id: "4", name: "정수익", avatar: "", bio: "사이드 프로젝트 전문가", followers: 1234 },
-  { id: "5", name: "최데브옵스", avatar: "", bio: "DevOps 엔지니어", followers: 987 },
-  { id: "6", name: "강경험", avatar: "", bio: "커리어 멘토", followers: 756 },
-]
+type LikedPostResponse = {
+  postId: number
+}
 
-// Mock feed posts
-const feedPosts: Post[] = [
-  {
-    id: "1",
-    title: "개발자의 번아웃 예방: 나만의 루틴 만들기",
-    excerpt: "10년차 개발자가 알려주는 번아웃 예방법. 지속 가능한 개발자 생활을 위한 팁들을 공유합니다.",
-    author: { name: "김개발" },
-    category: "자유 주제",
-    createdAt: "4시간 전",
-    likes: 234,
-    comments: 67,
-    views: 2890,
-    tags: ["번아웃", "루틴", "개발자생활"],
-  },
-  {
-    id: "2",
-    title: "네카라쿠배당토 신입 개발자 채용 트렌드 분석",
-    excerpt: "2026년 상반기 대기업 IT 기업들의 신입 개발자 채용 동향과 필요한 역량을 분석합니다.",
-    author: { name: "박취준" },
-    category: "취업 시장 정보",
-    createdAt: "5시간 전",
-    likes: 89,
-    comments: 15,
-    views: 892,
-    tags: ["취업", "신입채용", "대기업"],
-  },
-  {
-    id: "3",
-    title: "AI 코딩 어시스턴트 비교: Copilot vs Cursor vs Claude",
-    excerpt: "개발 생산성을 높여주는 AI 코딩 도구들을 실제 사용 경험을 바탕으로 비교 분석합니다.",
-    author: { name: "이트렌드" },
-    category: "개발자 트렌드",
-    createdAt: "1일 전",
-    likes: 256,
-    comments: 42,
-    views: 3240,
-    tags: ["ai", "copilot", "개발도구"],
-  },
-  {
-    id: "4",
-    title: "2026년 프론트엔드 개발자 로드맵: 꼭 알아야 할 기술 스택",
-    excerpt: "React, Next.js, TypeScript를 중심으로 2026년 프론트엔드 개발자가 반드시 알아야 할 기술들을 정리했습니다.",
-    author: { name: "김개발" },
-    category: "IT 기술 정보",
-    createdAt: "2일 전",
-    likes: 128,
-    comments: 24,
-    views: 1520,
-    tags: ["frontend", "react", "개발로드맵"],
-  },
-]
+function formatRelativeDate(value: string) {
+  if (!value) return ""
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMinutes = Math.floor(diffMs / 1000 / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffMinutes < 1) return "방금 전"
+  if (diffMinutes < 60) return `${diffMinutes}분 전`
+  if (diffHours < 24) return `${diffHours}시간 전`
+  if (diffDays < 30) return `${diffDays}일 전`
+
+  return date.toLocaleDateString("ko-KR")
+}
+
+function mapBookmarkedPostsToPostCard(
+  posts: BookmarkedPostResponse[],
+  likedPostIds: Set<number>,
+  bookmarkedPostIds: Set<number>
+): Post[] {
+  return posts.map((post) => ({
+    id: String(post.postId),
+    title: post.title,
+    excerpt: "",
+    author: { name: post.authorNickname },
+    category: "북마크",
+    createdAt: formatRelativeDate(post.createdAt),
+    likes: post.likeCount,
+    comments: post.commentCount,
+    views: 0,
+    tags: [],
+    liked: likedPostIds.has(post.postId),
+    bookmarked: bookmarkedPostIds.has(post.postId),
+  }))
+}
 
 export default function FeedPage() {
+  const router = useRouter()
   const [searchQuery, setSearchQuery] = useState("")
-  const hasFollowing = followedUsers.length > 0
+  const [bookmarkedPosts, setBookmarkedPosts] = useState<BookmarkedPostResponse[]>([])
+  const [likedPostIds, setLikedPostIds] = useState<Set<number>>(new Set())
+  const [bookmarkedPostIds, setBookmarkedPostIds] = useState<Set<number>>(new Set())
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    const auth = getAuthSnapshot()
+
+    if (!auth.isLoggedIn) {
+      router.replace("/login")
+      return
+    }
+
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        setError("")
+
+        const [bookmarksRes, likesRes] = await Promise.all([
+          apiFetch<BookmarkedPostResponse[]>("/api/mypage/bookmarks", {
+            method: "GET",
+            auth: true,
+          }),
+          apiFetch<LikedPostResponse[]>("/api/mypage/likes", {
+            method: "GET",
+            auth: true,
+          }),
+        ])
+
+        const bookmarks = bookmarksRes ?? []
+        const likes = likesRes ?? []
+
+        setBookmarkedPosts(bookmarks)
+        setBookmarkedPostIds(new Set(bookmarks.map((post) => post.postId)))
+        setLikedPostIds(new Set(likes.map((post) => post.postId)))
+      } catch (err) {
+        if (err instanceof Error && err.message === "UNAUTHORIZED") {
+          router.replace("/login")
+          return
+        }
+
+        console.error(err)
+        setError("북마크한 글을 불러오지 못했습니다.")
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void fetchData()
+  }, [router])
+
+  const handleBookmarkToggle = (postId: number, nextBookmarked: boolean) => {
+    setBookmarkedPostIds((prev) => {
+      const next = new Set(prev)
+
+      if (nextBookmarked) {
+        next.add(postId)
+      } else {
+        next.delete(postId)
+      }
+
+      return next
+    })
+
+    if (!nextBookmarked) {
+      setBookmarkedPosts((prev) => prev.filter((post) => post.postId !== postId))
+    }
+  }
+
+  const filteredPosts = useMemo(() => {
+    const keyword = searchQuery.trim().toLowerCase()
+
+    if (!keyword) return bookmarkedPosts
+
+    return bookmarkedPosts.filter(
+      (post) =>
+        post.title.toLowerCase().includes(keyword) ||
+        post.authorNickname.toLowerCase().includes(keyword)
+    )
+  }, [bookmarkedPosts, searchQuery])
+
+  const postCards = useMemo(
+    () => mapBookmarkedPostsToPostCard(filteredPosts, likedPostIds, bookmarkedPostIds),
+    [filteredPosts, likedPostIds, bookmarkedPostIds]
+  )
+
+  if (loading) return null
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div className="grid gap-8 lg:grid-cols-3">
-        {/* Main Content */}
         <div className="lg:col-span-2">
-          {/* Header */}
           <div className="mb-8 flex items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-              <Users className="h-5 w-5 text-primary" />
+              <Bookmark className="h-5 w-5 text-primary" />
             </div>
             <div>
-              <h1 className="text-3xl font-bold text-foreground">피드</h1>
-              <p className="text-muted-foreground">즐겨찾기한 사용자의 글을 모아봅니다</p>
+              <h1 className="text-3xl font-bold text-foreground">북마크</h1>
+              <p className="text-muted-foreground">북마크한 게시글을 모아봅니다</p>
             </div>
           </div>
 
-          {/* Feed Content */}
-          {hasFollowing && feedPosts.length > 0 ? (
+          {error ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+              {error}
+            </div>
+          ) : postCards.length > 0 ? (
             <div className="grid gap-6">
-              {feedPosts.map((post) => (
-                <PostCard key={post.id} post={post} />
+              {postCards.map((post) => (
+                <PostCard
+                  key={post.id}
+                  post={post}
+                  onBookmarkToggle={handleBookmarkToggle}
+                />
               ))}
             </div>
           ) : (
             <div className="rounded-lg border border-border bg-card p-12 text-center">
-              <Users className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+              <Bookmark className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
               <h3 className="mb-2 text-lg font-semibold text-foreground">
-                피드가 비어있습니다
+                북마크한 글이 없습니다
               </h3>
               <p className="mb-6 text-sm text-muted-foreground">
-                관심있는 작성자를 즐겨찾기하면 이곳에서 글을 모아볼 수 있습니다.
+                관심있는 게시글을 북마크하면 이곳에서 모아볼 수 있습니다.
               </p>
-              <Link href="/popular">
+
+              <Link href="/">
                 <Button className="bg-primary text-primary-foreground hover:bg-primary/90">
-                  인기 작성자 둘러보기
+                  게시글 둘러보기
                 </Button>
               </Link>
             </div>
           )}
         </div>
 
-        {/* Sidebar */}
         <div className="space-y-6">
-          {/* Following */}
           <div className="rounded-lg border border-border bg-card p-6">
             <div className="mb-4 flex items-center justify-between">
-              <h2 className="font-semibold text-foreground">즐겨찾기</h2>
+              <h2 className="font-semibold text-foreground">북마크한 글</h2>
               <span className="text-sm text-muted-foreground">
-                {followedUsers.length}명
+                {bookmarkedPosts.length}개
               </span>
             </div>
-            {followedUsers.length > 0 ? (
-              <div className="space-y-4">
-                {followedUsers.map((user) => (
-                  <Link
-                    key={user.id}
-                    href={`/user/${user.name}`}
-                    className="flex items-center gap-3 transition-colors hover:opacity-80"
-                  >
-                    <Avatar className="h-10 w-10">
-                      <AvatarImage src={user.avatar} alt={user.name} />
-                      <AvatarFallback className="bg-secondary text-secondary-foreground">
-                        {user.name.slice(0, 2)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="flex-1 overflow-hidden">
-                      <p className="truncate font-medium text-foreground">
-                        {user.name}
-                      </p>
-                      <p className="truncate text-sm text-muted-foreground">
-                        {user.bio}
-                      </p>
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            ) : (
-              <p className="text-center text-sm text-muted-foreground">
-                아직 즐겨찾기한 사용자가 없습니다
-              </p>
-            )}
+            <p className="text-sm text-muted-foreground">
+              저장해둔 게시글을 한곳에서 빠르게 확인할 수 있습니다.
+            </p>
           </div>
 
-          {/* Suggested Users */}
           <div className="rounded-lg border border-border bg-card p-6">
-            <h2 className="mb-4 font-semibold text-foreground">추천 작성자</h2>
-            <div className="mb-4">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  type="text"
-                  placeholder="작성자 검색..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="bg-secondary pl-9"
-                />
-              </div>
-            </div>
-            <div className="space-y-4">
-              {suggestedUsers.map((user) => (
-                <div key={user.id} className="flex items-center gap-3">
-                  <Link href={`/user/${user.name}`} className="flex items-center gap-3 flex-1">
-                    <Avatar className="h-10 w-10">
-                      <AvatarImage src={user.avatar} alt={user.name} />
-                      <AvatarFallback className="bg-secondary text-secondary-foreground">
-                        {user.name.slice(0, 2)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="flex-1 overflow-hidden">
-                      <p className="truncate font-medium text-foreground">
-                        {user.name}
-                      </p>
-                      <p className="truncate text-xs text-muted-foreground">
-                        팔로워 {user.followers.toLocaleString()}명
-                      </p>
-                    </div>
-                  </Link>
-                  <Button variant="outline" size="sm" className="gap-1">
-                    <UserPlus className="h-3 w-3" />
-                    <span className="sr-only sm:not-sr-only">팔로우</span>
-                  </Button>
-                </div>
-              ))}
+            <h2 className="mb-4 font-semibold text-foreground">북마크 검색</h2>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="제목 또는 작성자 검색..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="bg-secondary pl-9"
+              />
             </div>
           </div>
         </div>

--- a/frontend/app/mypage/comments/page.tsx
+++ b/frontend/app/mypage/comments/page.tsx
@@ -3,26 +3,42 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { MessageCircle } from "lucide-react";
 import { apiFetch } from "@/lib/api";
 import { getAuthSnapshot } from "@/lib/auth-storage";
 
-type SuccessResponse<T> = {
-  code: string;
-  message: string;
-  timestamp: string;
-  data: T;
-};
-
-type MyCommentResponse = {
+type MyCommentItem = {
   commentId: number;
   postId: number;
+  postTitle: string;
   content: string;
   createdAt: string;
 };
 
+type MyCommentsApiResponse = {
+  comments: MyCommentItem[];
+};
+
+function formatDate(value: string) {
+  if (!value) return "";
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
 export default function MyCommentsPage() {
+  console.log("=== MyCommentsPage 실제 파일 실행됨 ===");
+
   const router = useRouter();
-  const [comments, setComments] = useState<MyCommentResponse[]>([]);
+  const [comments, setComments] = useState<MyCommentItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -39,22 +55,23 @@ export default function MyCommentsPage() {
         setLoading(true);
         setError("");
 
-        const res = await apiFetch<SuccessResponse<MyCommentResponse[]>>(
-          "/users/me/comments",
-          {
-            method: "GET",
-            auth: true,
-          }
-        );
+        const res = await apiFetch<MyCommentsApiResponse>("/mypage/comments", {
+          method: "GET",
+          auth: true,
+        });
 
-        setComments(res.data ?? []);
+        console.log("댓글 응답:", res);
+        console.log("댓글 목록:", res?.comments);
+
+        setComments(res?.comments ?? []);
       } catch (err) {
+        console.error("댓글 조회 실패:", err);
+
         if (err instanceof Error && err.message === "UNAUTHORIZED") {
           router.replace("/login");
           return;
         }
 
-        console.error(err);
         setError("내 댓글을 불러오지 못했습니다.");
       } finally {
         setLoading(false);
@@ -66,9 +83,18 @@ export default function MyCommentsPage() {
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-10">
+      <div className="mb-6 rounded-xl border border-red-500 bg-red-500/10 p-4">
+        <h1 className="text-2xl font-bold text-red-500">
+          MyCommentsPage 테스트중
+        </h1>
+        <p className="mt-1 text-sm text-red-400">
+          이 문구가 보이면 지금 수정한 파일이 실제로 렌더링되고 있는 거다.
+        </p>
+      </div>
+
       <div className="mb-6 flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">내가 쓴 댓글</h1>
+          <h2 className="text-2xl font-bold">내가 쓴 댓글</h2>
           <p className="mt-1 text-sm text-muted-foreground">
             내가 작성한 댓글 목록입니다.
           </p>
@@ -77,6 +103,15 @@ export default function MyCommentsPage() {
         <Link href="/mypage" className="rounded-lg border px-4 py-2 text-sm">
           마이페이지로
         </Link>
+      </div>
+
+      <div className="mb-6 rounded-2xl border p-4 text-sm">
+        <p>
+          <strong>디버그 정보</strong>
+        </p>
+        <p>loading: {String(loading)}</p>
+        <p>error: {error || "없음"}</p>
+        <p>comments.length: {comments.length}</p>
       </div>
 
       {loading && <div className="rounded-2xl border p-6">로딩 중...</div>}
@@ -95,18 +130,36 @@ export default function MyCommentsPage() {
         {!loading &&
           !error &&
           comments.map((comment) => (
-            <div key={comment.commentId} className="rounded-2xl border p-5">
-              <div className="mb-3 flex items-center justify-between gap-4">
-                <h2 className="text-sm font-medium">
-                  게시글 ID: {comment.postId}
-                </h2>
+            <Link
+              key={comment.commentId}
+              href={`/posts/${comment.postId}#comment-${comment.commentId}`}
+              className="block rounded-2xl border p-5 transition-colors hover:border-primary/50 hover:bg-card/60"
+            >
+              <div className="mb-3 flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="mb-2 inline-flex items-center gap-2 rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                    <MessageCircle className="h-3.5 w-3.5" />
+                    내가 작성한 댓글
+                  </p>
+
+                  <h2 className="truncate text-base font-semibold text-foreground">
+                    {comment.postTitle || `게시글 #${comment.postId}`}
+                  </h2>
+                </div>
+
                 <span className="shrink-0 text-xs text-muted-foreground">
-                  {comment.createdAt}
+                  {formatDate(comment.createdAt)}
                 </span>
               </div>
 
-              <p className="text-sm text-muted-foreground">{comment.content}</p>
-            </div>
+              <p className="mb-3 line-clamp-2 text-sm text-muted-foreground">
+                {comment.content}
+              </p>
+
+              <p className="text-xs text-muted-foreground">
+                클릭하면 해당 게시글로 이동합니다
+              </p>
+            </Link>
           ))}
       </div>
     </main>

--- a/frontend/app/mypage/edit/page.tsx
+++ b/frontend/app/mypage/edit/page.tsx
@@ -1,4 +1,4 @@
-"use client"
+﻿"use client"
 
 import { ChangeEvent, FormEvent, useEffect, useState } from "react"
 import Link from "next/link"
@@ -33,6 +33,10 @@ type MyProfileResponse = {
 }
 
 type UpdateMyProfileRequest = {
+  nickname: string
+}
+
+type ProfileForm = {
   email: string
   nickname: string
 }
@@ -48,7 +52,7 @@ type LocalProfileForm = {
 export default function MyPageEditPage() {
   const router = useRouter()
 
-  const [form, setForm] = useState<UpdateMyProfileRequest>({
+  const [form, setForm] = useState<ProfileForm>({
     email: "",
     nickname: "",
   })
@@ -131,11 +135,6 @@ export default function MyPageEditPage() {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    if (!form.email.trim()) {
-      alert("이메일을 입력해주세요.")
-      return
-    }
-
     if (!form.nickname.trim()) {
       alert("닉네임을 입력해주세요.")
       return
@@ -144,13 +143,14 @@ export default function MyPageEditPage() {
     try {
       setSubmitting(true)
 
+      const requestBody: UpdateMyProfileRequest = {
+        nickname: form.nickname.trim(),
+      }
+
       const updatedProfile = await apiFetch<MyProfileResponse>("/api/mypage", {
         method: "PATCH",
         auth: true,
-        body: JSON.stringify({
-          email: form.email.trim(),
-          nickname: form.nickname.trim(),
-        }),
+        body: JSON.stringify(requestBody),
       })
 
       persistLoginSession(undefined, updatedProfile.nickname, updatedProfile.email)
@@ -288,9 +288,8 @@ export default function MyPageEditPage() {
                 name="email"
                 type="email"
                 value={form.email}
-                onChange={handleChange}
-                placeholder="이메일을 입력하세요"
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+                readOnly
+                className="w-full cursor-not-allowed rounded-lg border border-border bg-muted px-3 py-2 text-sm text-muted-foreground outline-none"
               />
             </div>
 

--- a/frontend/app/mypage/page.tsx
+++ b/frontend/app/mypage/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react"
 import type React from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { PostCard, type Post } from "@/components/post-card"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -42,11 +42,16 @@ type MyPostResponse = {
   createdAt: string
 }
 
-type MyCommentResponse = {
+type MyCommentItem = {
   commentId: number
   postId: number
+  postTitle: string
   content: string
   createdAt: string
+}
+
+type MyCommentsResponse = {
+  comments: MyCommentItem[]
 }
 
 type LikedPostResponse = {
@@ -218,6 +223,7 @@ function mapLikedPostsToPostCard(posts: LikedPostResponse[]): Post[] {
 
 export default function MyPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
 
   const [activeTab, setActiveTab] = useState("posts")
   const [displayName, setDisplayName] = useState("김개발")
@@ -232,7 +238,7 @@ export default function MyPage() {
   const [myPosts, setMyPosts] = useState<MyPostResponse[]>([])
   const [bookmarkedPosts, setBookmarkedPosts] = useState<BookmarkedPostResponse[]>([])
   const [likedPosts, setLikedPosts] = useState<LikedPostResponse[]>([])
-  const [myComments, setMyComments] = useState<MyCommentResponse[]>([])
+  const [myComments, setMyComments] = useState<MyCommentItem[]>([])
 
   const [bookmarkCount, setBookmarkCount] = useState(0)
   const [likeCount, setLikeCount] = useState(0)
@@ -272,6 +278,19 @@ export default function MyPage() {
     () => mapLikedPostsToPostCard(likedPosts),
     [likedPosts]
   )
+
+  useEffect(() => {
+    const tab = searchParams.get("tab")
+
+    if (
+      tab === "posts" ||
+      tab === "bookmarks" ||
+      tab === "likes" ||
+      tab === "comments"
+    ) {
+      setActiveTab(tab)
+    }
+  }, [searchParams])
 
   useEffect(() => {
     const fetchInitialData = async () => {
@@ -339,7 +358,7 @@ export default function MyPage() {
             method: "GET",
             auth: true,
           }),
-          apiFetch<MyCommentResponse[]>("/api/mypage/comments", {
+          apiFetch<MyCommentsResponse>("/api/mypage/comments", {
             method: "GET",
             auth: true,
           }),
@@ -358,7 +377,7 @@ export default function MyPage() {
         }
 
         if (commentsRes.status === "fulfilled") {
-          setCommentCount(commentsRes.value?.length ?? 0)
+          setCommentCount(commentsRes.value?.comments?.length ?? 0)
         }
       } catch (err) {
         console.error(err)
@@ -483,13 +502,13 @@ export default function MyPage() {
         setTabLoading(true)
         setError("")
 
-        const res = await apiFetch<MyCommentResponse[]>("/api/mypage/comments", {
+        const res = await apiFetch<MyCommentsResponse>("/api/mypage/comments", {
           method: "GET",
           auth: true,
         })
 
-        setMyComments(res ?? [])
-        setCommentCount(res?.length ?? 0)
+        setMyComments(res?.comments ?? [])
+        setCommentCount(res?.comments?.length ?? 0)
       } catch (err) {
         console.error(err)
         setError("댓글 목록을 불러오지 못했습니다.")
@@ -706,20 +725,32 @@ export default function MyPage() {
           {tabLoading ? null : myComments.length > 0 ? (
             <div className="grid gap-4">
               {myComments.map((comment) => (
-                <div
+                <Link
                   key={comment.commentId}
-                  className="rounded-lg border border-border bg-card p-5"
+                  href={`/posts/${comment.postId}#comment-${comment.commentId}`}
+                  className="block rounded-lg border border-border bg-card p-5 transition-colors hover:border-primary/50 hover:bg-card/80"
                 >
-                  <div className="mb-2 flex items-center justify-between gap-4">
-                    <p className="text-sm text-foreground">{comment.content}</p>
-                    <span className="text-xs text-muted-foreground">
+                  <div className="mb-3 flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="mb-2 inline-flex items-center gap-2 rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                        <MessageCircle className="h-3.5 w-3.5" />
+                        내가 작성한 댓글
+                      </p>
+
+                      <h3 className="truncate text-base font-semibold text-foreground">
+                        {comment.postTitle}
+                      </h3>
+                    </div>
+
+                    <span className="shrink-0 text-xs text-muted-foreground">
                       {formatRelativeDate(comment.createdAt)}
                     </span>
                   </div>
-                  <p className="text-xs text-muted-foreground">
-                    게시글 ID: {comment.postId}
+
+                  <p className="line-clamp-2 text-sm text-muted-foreground">
+                    {comment.content}
                   </p>
-                </div>
+                </Link>
               ))}
             </div>
           ) : (

--- a/frontend/app/mypage/posts/page.tsx
+++ b/frontend/app/mypage/posts/page.tsx
@@ -1,116 +1,163 @@
-"use client";
+"use client"
 
-import Link from "next/link";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { apiFetch } from "@/lib/api";
-import { getAuthSnapshot } from "@/lib/auth-storage";
-
-type SuccessResponse<T> = {
-  code: string;
-  message: string;
-  timestamp: string;
-  data: T;
-};
+import { useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
+import { PostCard, type Post } from "@/components/post-card"
+import { apiFetch } from "@/lib/api"
+import { getAuthSnapshot } from "@/lib/auth-storage"
 
 type MyPostResponse = {
-  postId: number;
-  title: string;
-  likeCount: number;
-  commentCount: number;
-  createdAt: string;
-};
+  postId: number
+  title: string
+  likeCount: number
+  commentCount: number
+  createdAt: string
+}
+
+type MyProfileResponse = {
+  nickname: string
+}
+
+type LikedPostResponse = {
+  postId: number
+}
+
+type BookmarkedPostResponse = {
+  postId: number
+}
+
+function formatRelativeDate(value: string) {
+  if (!value) return ""
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMinutes = Math.floor(diffMs / 1000 / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffMinutes < 1) return "방금 전"
+  if (diffMinutes < 60) return `${diffMinutes}분 전`
+  if (diffHours < 24) return `${diffHours}시간 전`
+  if (diffDays < 30) return `${diffDays}일 전`
+
+  return date.toLocaleDateString("ko-KR")
+}
+
+function mapMyPostsToPostCard(
+  posts: MyPostResponse[],
+  nickname: string,
+  likedPostIds: Set<number>,
+  bookmarkedPostIds: Set<number>
+): Post[] {
+  return posts.map((post) => ({
+    id: String(post.postId),
+    title: post.title,
+    excerpt: "",
+    author: { name: nickname },
+    category: "내 글",
+    createdAt: formatRelativeDate(post.createdAt),
+    likes: post.likeCount,
+    comments: post.commentCount,
+    views: 0,
+    tags: [],
+    liked: likedPostIds.has(post.postId),
+    bookmarked: bookmarkedPostIds.has(post.postId),
+  }))
+}
 
 export default function MyPostsPage() {
-  const router = useRouter();
-  const [posts, setPosts] = useState<MyPostResponse[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
+  const router = useRouter()
+  const [posts, setPosts] = useState<MyPostResponse[]>([])
+  const [nickname, setNickname] = useState("")
+  const [likedPostIds, setLikedPostIds] = useState<Set<number>>(new Set())
+  const [bookmarkedPostIds, setBookmarkedPostIds] = useState<Set<number>>(new Set())
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
 
   useEffect(() => {
-    const auth = getAuthSnapshot();
+    const auth = getAuthSnapshot()
 
-    if (!auth.token) {
-      router.replace("/login");
-      return;
+    if (!auth.isLoggedIn) {
+      router.replace("/login")
+      return
     }
 
-    const fetchPosts = async () => {
+    const fetchData = async () => {
       try {
-        setLoading(true);
-        setError("");
+        setLoading(true)
+        setError("")
 
-        const res = await apiFetch<SuccessResponse<MyPostResponse[]>>(
-          "/users/me/posts",
-          {
+        const [postsRes, profileRes, likesRes, bookmarksRes] = await Promise.all([
+          apiFetch<MyPostResponse[]>("/api/mypage/posts", {
             method: "GET",
             auth: true,
-          }
-        );
+          }),
+          apiFetch<MyProfileResponse>("/api/mypage", {
+            method: "GET",
+            auth: true,
+          }),
+          apiFetch<LikedPostResponse[]>("/api/mypage/likes", {
+            method: "GET",
+            auth: true,
+          }),
+          apiFetch<BookmarkedPostResponse[]>("/api/mypage/bookmarks", {
+            method: "GET",
+            auth: true,
+          }),
+        ])
 
-        setPosts(res.data ?? []);
+        setPosts(postsRes ?? [])
+        setNickname(profileRes?.nickname ?? "")
+        setLikedPostIds(new Set((likesRes ?? []).map((post) => post.postId)))
+        setBookmarkedPostIds(new Set((bookmarksRes ?? []).map((post) => post.postId)))
       } catch (err) {
         if (err instanceof Error && err.message === "UNAUTHORIZED") {
-          router.replace("/login");
-          return;
+          router.replace("/login")
+          return
         }
 
-        console.error(err);
-        setError("내가 쓴 글을 불러오지 못했습니다.");
+        console.error(err)
+        setError("내가 쓴 글을 불러오지 못했습니다.")
       } finally {
-        setLoading(false);
+        setLoading(false)
       }
-    };
+    }
 
-    fetchPosts();
-  }, [router]);
+    void fetchData()
+  }, [router])
+
+  const postCards = useMemo(
+    () => mapMyPostsToPostCard(posts, nickname, likedPostIds, bookmarkedPostIds),
+    [posts, nickname, likedPostIds, bookmarkedPostIds]
+  )
+
+  if (loading) return null
 
   return (
-    <main className="mx-auto max-w-4xl px-4 py-10">
-      <div className="mb-6 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">내가 쓴 글</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            내가 작성한 게시글 목록입니다.
-          </p>
+    <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      {error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+          {error}
         </div>
+      ) : null}
 
-        <Link href="/mypage" className="rounded-lg border px-4 py-2 text-sm">
-          마이페이지로
-        </Link>
-      </div>
-
-      {loading && <div className="rounded-2xl border p-6">로딩 중...</div>}
-
-      {!loading && error && (
-        <div className="rounded-2xl border p-6">
-          <p className="text-sm text-red-500">{error}</p>
+      {!error && postCards.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-12 text-center">
+          <h3 className="mb-2 text-lg font-semibold text-foreground">작성한 글이 없습니다</h3>
+          <p className="text-sm text-muted-foreground">첫 번째 글을 작성해보세요</p>
         </div>
-      )}
+      ) : null}
 
-      {!loading && !error && posts.length === 0 && (
-        <div className="rounded-2xl border p-6">작성한 글이 없습니다.</div>
-      )}
-
-      <div className="space-y-4">
-        {!loading &&
-          !error &&
-          posts.map((post) => (
-            <div key={post.postId} className="rounded-2xl border p-5">
-              <div className="mb-3 flex items-center justify-between gap-4">
-                <h2 className="text-lg font-semibold">{post.title}</h2>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {post.createdAt}
-                </span>
-              </div>
-
-              <div className="flex gap-4 text-sm text-muted-foreground">
-                <span>좋아요 {post.likeCount}</span>
-                <span>댓글 {post.commentCount}</span>
-              </div>
-            </div>
+      {!error && postCards.length > 0 ? (
+        <div className="grid gap-6">
+          {postCards.map((post) => (
+            <PostCard key={post.id} post={post} />
           ))}
-      </div>
+        </div>
+      ) : null}
     </main>
-  );
+  )
 }

--- a/frontend/components/interaction-buttons.tsx
+++ b/frontend/components/interaction-buttons.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import type React from "react"
 import { Heart, Bookmark } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { getAccessToken } from "@/lib/auth-storage"
+import { getAccessToken, getAuthSnapshot } from "@/lib/auth-storage"
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
@@ -14,6 +14,7 @@ type InteractionButtonsProps = {
   initialLiked?: boolean
   initialBookmarked?: boolean
   initialLikeCount?: number
+  onBookmarkToggle?: (nextBookmarked: boolean) => void
 }
 
 type LikeResponse = {
@@ -66,6 +67,7 @@ export default function InteractionButtons({
   initialLiked = false,
   initialBookmarked = false,
   initialLikeCount = 0,
+  onBookmarkToggle,
 }: InteractionButtonsProps) {
   const [liked, setLiked] = useState(initialLiked)
   const [bookmarked, setBookmarked] = useState(initialBookmarked)
@@ -85,11 +87,24 @@ export default function InteractionButtons({
     setLikeCount(initialLikeCount)
   }, [initialLikeCount])
 
+  const requireAuth = () => {
+    const auth = getAuthSnapshot()
+
+    if (!auth.isLoggedIn) {
+      alert("인증이 필요합니다.")
+      return false
+    }
+
+    return true
+  }
+
   const handleLike = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
     e.stopPropagation()
 
+    if (!requireAuth()) return
     if (likeLoading) return
+
     setLikeLoading(true)
 
     try {
@@ -104,10 +119,16 @@ export default function InteractionButtons({
       const parsed = await parseResponse(res)
 
       if (!res.ok) {
+        if (res.status === 401) {
+          alert("인증이 필요합니다.")
+          return
+        }
+
         const message =
           typeof parsed === "string"
             ? parsed || "좋아요 처리 실패"
             : parsed?.message || "좋아요 처리 실패"
+
         throw new Error(message)
       }
 
@@ -130,7 +151,9 @@ export default function InteractionButtons({
     e.preventDefault()
     e.stopPropagation()
 
+    if (!requireAuth()) return
     if (bookmarkLoading) return
+
     setBookmarkLoading(true)
 
     try {
@@ -145,15 +168,24 @@ export default function InteractionButtons({
       const parsed = await parseResponse(res)
 
       if (!res.ok) {
+        if (res.status === 401) {
+          alert("인증이 필요합니다.")
+          return
+        }
+
         const message =
           typeof parsed === "string"
             ? parsed || "북마크 처리 실패"
             : parsed?.message || "북마크 처리 실패"
+
         throw new Error(message)
       }
 
       const data = parsed as BookmarkResponse
-      setBookmarked(Boolean(data.bookmarked))
+      const nextBookmarked = Boolean(data.bookmarked)
+
+      setBookmarked(nextBookmarked)
+      onBookmarkToggle?.(nextBookmarked)
 
       window.dispatchEvent(new CustomEvent("notifications-updated"))
     } catch (error: any) {

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -229,7 +229,7 @@ export function Header() {
             최신글
           </Link>
           <Link href="/feed" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            피드
+            북마크
           </Link>
         </nav>
 

--- a/frontend/components/post-card.tsx
+++ b/frontend/components/post-card.tsx
@@ -24,9 +24,10 @@ export interface Post {
 
 interface PostCardProps {
   post: Post
+  onBookmarkToggle?: (postId: number, nextBookmarked: boolean) => void
 }
 
-export function PostCard({ post }: PostCardProps) {
+export function PostCard({ post, onBookmarkToggle }: PostCardProps) {
   const authorProfileHref = post.author.userId
     ? `/users/${post.author.userId}`
     : undefined
@@ -115,6 +116,9 @@ export function PostCard({ post }: PostCardProps) {
           initialLiked={post.liked ?? false}
           initialBookmarked={post.bookmarked ?? false}
           initialLikeCount={post.likes ?? 0}
+          onBookmarkToggle={(nextBookmarked) =>
+            onBookmarkToggle?.(Number(post.id), nextBookmarked)
+          }
         />
       </div>
     </article>


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #142 

## 🛠️ 작업 내용
- [x] 마이페이지 프로필 수정 시 이메일 수정 불가하도록 변경
- [x] 프로필 수정 API에서 email 필드 제거 및 nickname만 수정하도록 수정
- [x] 프론트에서 이메일 input을 readOnly 처리
- [x] 프로필 수정 요청 시 email 값 제거 (nickname만 전송)

## 🎯 리뷰 포인트
- 이메일 수정 기능을 완전히 제거하는 방향으로 처리했는데 확인 부탁드립니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?