### PR TITLE
refactor: 댓글·알림 컨트롤러 응답 형식 공통화

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
@@ -13,6 +13,8 @@ import com.back.devc.global.security.jwt.JwtPrincipal;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.Authentication;
+import com.back.devc.global.response.SuccessResponse;
+import com.back.devc.global.response.SuccessCode;
 
 /**
  * 알림 조회/읽음 처리 API 컨트롤러
@@ -48,8 +50,12 @@ public class NotificationController {
      * - OAuth 로그인 사용자는 OAuth2User에서 email을 꺼낸 뒤 Member를 조회해서 userId를 얻음
      */
     @GetMapping
-    public ResponseEntity<NotificationListResponse> getMyNotifications(Authentication authentication) {
-        return ResponseEntity.ok(notificationService.getMyNotifications(getAuthenticatedUserId(authentication)));
+    public ResponseEntity<SuccessResponse<NotificationListResponse>> getMyNotifications(Authentication authentication) {
+        NotificationListResponse response = notificationService.getMyNotifications(getAuthenticatedUserId(authentication));
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessCode.NOTIFICATION_LIST_SUCCESS, response)
+        );
     }
 
     /**
@@ -59,11 +65,18 @@ public class NotificationController {
      * 실제 service 계층에서 "이 알림이 현재 로그인한 사용자의 알림인지"를 함께 검증하기 때문
      */
     @PatchMapping("/{notificationId}/read")
-    public ResponseEntity<NotificationResponse> readNotification(
+    public ResponseEntity<SuccessResponse<NotificationResponse>> readNotification(
             Authentication authentication,
             @PathVariable Long notificationId
     ) {
-        return ResponseEntity.ok(notificationService.readNotification(notificationId, getAuthenticatedUserId(authentication)));
+        NotificationResponse response = notificationService.readNotification(
+                notificationId,
+                getAuthenticatedUserId(authentication)
+        );
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessCode.NOTIFICATION_READ_SUCCESS, response)
+        );
     }
 
     /**

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
@@ -13,6 +13,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import static com.back.devc.global.security.jwt.JwtPrincipalHelper.getAuthenticatedUserId;
 
+import com.back.devc.global.response.SuccessResponse;
+import com.back.devc.global.response.SuccessCode;
+
 import java.util.List;
 
 @RestController
@@ -29,7 +32,7 @@ public class CommentAttachmentController {
      * 따라서 현재 로그인 사용자를 SecurityContext 안의 JwtPrincipal 에서 확인한 뒤 처리
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<CommentAttachmentListResponse> uploadCommentAttachments(
+    public ResponseEntity<SuccessResponse<CommentAttachmentListResponse>> uploadCommentAttachments(
             @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long commentId,
             @RequestParam("files") List<MultipartFile> files,
@@ -37,17 +40,21 @@ public class CommentAttachmentController {
     ) {
         getAuthenticatedUserId(principal);
 
+        CommentAttachmentListResponse response = commentAttachmentService.uploadAttachments(commentId, files, fileOrders);
+
         return ResponseEntity.ok(
-                commentAttachmentService.uploadAttachments(commentId, files, fileOrders)
+                SuccessResponse.of(SuccessCode.COMMENT_ATTACHMENT_UPLOAD_SUCCESS, response)
         );
     }
 
     @GetMapping
-    public ResponseEntity<CommentAttachmentListResponse> getCommentAttachments(
+    public ResponseEntity<SuccessResponse<CommentAttachmentListResponse>> getCommentAttachments(
             @PathVariable Long commentId
     ) {
+        CommentAttachmentListResponse response = commentAttachmentService.getAttachments(commentId);
+
         return ResponseEntity.ok(
-                commentAttachmentService.getAttachments(commentId)
+                SuccessResponse.of(SuccessCode.COMMENT_ATTACHMENT_LIST_SUCCESS, response)
         );
     }
 
@@ -57,15 +64,17 @@ public class CommentAttachmentController {
      * 업로드와 동일하게 현재 로그인한 사용자 기준으로만 요청을 허용
      */
     @DeleteMapping("/{attachmentId}")
-    public ResponseEntity<CommentAttachmentDeleteResponse> deleteCommentAttachment(
+    public ResponseEntity<SuccessResponse<CommentAttachmentDeleteResponse>> deleteCommentAttachment(
             @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long commentId,
             @PathVariable Long attachmentId
     ) {
         getAuthenticatedUserId(principal);
 
+        CommentAttachmentDeleteResponse response = commentAttachmentService.deleteAttachment(commentId, attachmentId);
+
         return ResponseEntity.ok(
-                commentAttachmentService.deleteAttachment(commentId, attachmentId)
+                SuccessResponse.of(SuccessCode.COMMENT_ATTACHMENT_DELETE_SUCCESS, response)
         );
     }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
@@ -6,6 +6,8 @@ import com.back.devc.domain.post.comment.dto.CommentListResponse;
 import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.dto.CommentUpdateRequest;
 import com.back.devc.domain.post.comment.service.CommentService;
+import com.back.devc.global.response.SuccessResponse;
+import com.back.devc.global.response.SuccessCode;
 import com.back.devc.global.security.jwt.JwtPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,12 +32,20 @@ public class CommentController {
      * 이렇게 해야 다른 사용자의 userId를 임의로 넣어 댓글을 작성하는 것을 막을 수 있다.
      */
     @PostMapping("/posts/{postId}/comments")
-    public ResponseEntity<CommentResponse> createComment(
+    public ResponseEntity<SuccessResponse<CommentResponse>> createComment(
             @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long postId,
             @RequestBody @Valid CommentCreateRequest request
     ) {
-        return ResponseEntity.ok(commentService.createComment(postId, getAuthenticatedUserId(principal), request));
+        CommentResponse response = commentService.createComment(
+                postId,
+                getAuthenticatedUserId(principal),
+                request
+        );
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessCode.COMMENT_CREATE_SUCCESS, response)
+        );
     }
 
     /**
@@ -44,12 +54,20 @@ public class CommentController {
      * 답글도 일반 댓글과 동일하게 현재 로그인한 사용자 기준으로만 작성
      */
     @PostMapping("/comments/{commentId}/replies")
-    public ResponseEntity<CommentResponse> createReply(
+    public ResponseEntity<SuccessResponse<CommentResponse>> createReply(
             @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long commentId,
             @RequestBody @Valid CommentCreateRequest request
     ) {
-        return ResponseEntity.ok(commentService.createReply(commentId, getAuthenticatedUserId(principal), request));
+        CommentResponse response = commentService.createReply(
+                commentId,
+                getAuthenticatedUserId(principal),
+                request
+        );
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessCode.COMMENT_REPLY_SUCCESS, response)
+        );
     }
 
     /**
@@ -59,12 +77,20 @@ public class CommentController {
      * service 계층에서 "본인이 작성한 댓글인지"를 검증할 수 있게 함
      */
     @PatchMapping("/comments/{commentId}")
-    public ResponseEntity<CommentResponse> updateComment(
+    public ResponseEntity<SuccessResponse<CommentResponse>> updateComment(
             @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long commentId,
             @RequestBody @Valid CommentUpdateRequest request
     ) {
-        return ResponseEntity.ok(commentService.updateComment(commentId, getAuthenticatedUserId(principal), request));
+        CommentResponse response = commentService.updateComment(
+                commentId,
+                getAuthenticatedUserId(principal),
+                request
+        );
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessCode.COMMENT_UPDATE_SUCCESS, response)
+        );
     }
 
     /**
@@ -74,16 +100,27 @@ public class CommentController {
      * 실제 삭제 가능 여부(본인 댓글인지 등)는 service 계층에서 검증
      */
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<CommentDeleteResponse> deleteComment(
+    public ResponseEntity<SuccessResponse<CommentDeleteResponse>> deleteComment(
             @AuthenticationPrincipal JwtPrincipal principal,
             @PathVariable Long commentId
     ) {
-        return ResponseEntity.ok(commentService.deleteComment(commentId, getAuthenticatedUserId(principal)));
+        CommentDeleteResponse response = commentService.deleteComment(
+                commentId,
+                getAuthenticatedUserId(principal)
+        );
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessCode.COMMENT_DELETE_SUCCESS, response)
+        );
     }
 
     @GetMapping("/posts/{postId}/comments")
-    public ResponseEntity<CommentListResponse> getComments(@PathVariable Long postId) {
-        return ResponseEntity.ok(commentService.getComments(postId));
+    public ResponseEntity<SuccessResponse<CommentListResponse>> getComments(@PathVariable Long postId) {
+        CommentListResponse response = commentService.getComments(postId);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessCode.COMMENT_LIST_SUCCESS, response)
+        );
     }
 
 }

--- a/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
@@ -18,6 +18,23 @@ public enum SuccessCode {
     // 신고 관련 성공 코드
     REPORT_SUCCESS(HttpStatus.OK, "REPORT_200", "신고가 정상적으로 접수되었습니다."),
 
+    // 알림 관련 성공 코드
+    NOTIFICATION_LIST_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_LIST", "알림 목록 조회 성공"),
+    NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_READ", "알림 읽음 처리 성공"),
+
+
+    // 댓글 첨부파일 관련 성공 코드
+    COMMENT_ATTACHMENT_UPLOAD_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_UPLOAD", "댓글 첨부파일 업로드 성공"),
+    COMMENT_ATTACHMENT_LIST_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_LIST", "댓글 첨부파일 조회 성공"),
+    COMMENT_ATTACHMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_DELETE", "댓글 첨부파일 삭제 성공"),
+
+    // 댓글 관련 성공 코드
+    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_200_CREATE", "댓글 작성 성공"),
+    COMMENT_REPLY_SUCCESS(HttpStatus.OK, "COMMENT_200_REPLY", "대댓글 작성 성공"),
+    COMMENT_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_200_UPDATE", "댓글 수정 성공"),
+    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_200_DELETE", "댓글 삭제 성공"),
+    COMMENT_LIST_SUCCESS(HttpStatus.OK, "COMMENT_200_LIST", "댓글 목록 조회 성공"),
+
     // 회원 탈퇴 성공 코드
     WITHDRAW_SUCCESS(HttpStatus.OK, "USER_200_WITHDRAW_SUCCESS", "회원 탈퇴가 완료되었습니다.");
 


### PR DESCRIPTION
## 📌 관련 이슈

Closes #147 

## 🛠️ 작업 내용
- `NotificationController` 응답을 `SuccessResponse` 형식으로 통일

- `CommentController` 응답을 `SuccessResponse` 형식으로 통일

- `CommentAttachmentController` 응답을 `SuccessResponse` 형식으로 통일

- 알림 관련 성공 코드를 `SuccessCode`에 추가

- 댓글 관련 성공 코드를 `SuccessCode`에 추가

- 댓글 첨부파일 관련 성공 코드를 `SuccessCode`에 추가

- 컨트롤러 내 문자열 하드코딩 응답 코드를 enum 기반으로 변경

## 🎯 리뷰 포인트
- `SuccessResponse`와 `SuccessCode`를 사용하는 방식이 기존 프로젝트 응답 패턴과 일관적인지

- 댓글/알림/댓글 첨부파일 컨트롤러의 응답 형식이 동일한 기준으로 적용되었는지

- 성공 코드 네이밍이 도메인별로 명확하게 구분되는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?