### PR TITLE
fix: 댓글 첨부파일 업로드 및 응답 형식 정리

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
@@ -52,10 +52,11 @@ public class NotificationController {
     @GetMapping
     public ResponseEntity<SuccessResponse<NotificationListResponse>> getMyNotifications(Authentication authentication) {
         NotificationListResponse response = notificationService.getMyNotifications(getAuthenticatedUserId(authentication));
+        SuccessCode successCode = SuccessCode.NOTIFICATION_200_LIST_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.NOTIFICATION_LIST_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     /**
@@ -73,10 +74,11 @@ public class NotificationController {
                 notificationId,
                 getAuthenticatedUserId(authentication)
         );
+        SuccessCode successCode = SuccessCode.NOTIFICATION_200_READ_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.NOTIFICATION_READ_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     /**

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
@@ -41,10 +41,11 @@ public class CommentAttachmentController {
         getAuthenticatedUserId(principal);
 
         CommentAttachmentListResponse response = commentAttachmentService.uploadAttachments(commentId, files, fileOrders);
+        SuccessCode successCode = SuccessCode.COMMENT_ATTACHMENT_201_UPLOAD_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_ATTACHMENT_UPLOAD_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     @GetMapping
@@ -52,10 +53,11 @@ public class CommentAttachmentController {
             @PathVariable Long commentId
     ) {
         CommentAttachmentListResponse response = commentAttachmentService.getAttachments(commentId);
+        SuccessCode successCode = SuccessCode.COMMENT_ATTACHMENT_200_LIST_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_ATTACHMENT_LIST_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     /**
@@ -72,10 +74,11 @@ public class CommentAttachmentController {
         getAuthenticatedUserId(principal);
 
         CommentAttachmentDeleteResponse response = commentAttachmentService.deleteAttachment(commentId, attachmentId);
+        SuccessCode successCode = SuccessCode.COMMENT_ATTACHMENT_200_DELETE_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_ATTACHMENT_DELETE_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentService.java
@@ -13,6 +13,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +28,7 @@ public class CommentAttachmentService {
 
     private final CommentAttachmentRepository commentAttachmentRepository;
     private final CommentRepository commentRepository;
+    private static final Path COMMENT_UPLOAD_DIR = Paths.get("uploads", "comments");
 
     @Transactional
     public CommentAttachmentListResponse uploadAttachments(
@@ -45,17 +53,22 @@ public class CommentAttachmentService {
 
             String originalFilename = file.getOriginalFilename() != null
                     ? file.getOriginalFilename()
-                    : "";
+                    : "unnamed";
             String contentType = file.getContentType() != null
                     ? file.getContentType()
-                    : "";
+                    : "application/octet-stream";
+            String extension = extractExtension(originalFilename);
+            String storedName = UUID.randomUUID() + extension;
+            String fileType = contentType.startsWith("image/") ? "IMAGE" : "FILE";
+            saveFile(file, storedName);
+            String fileUrl = "/uploads/comments/" + storedName;
 
             CommentAttachment attachment = CommentAttachment.create(
                     commentId,
                     originalFilename,
-                    originalFilename,
-                    "",
-                    "",
+                    storedName,
+                    fileUrl,
+                    fileType,
                     contentType,
                     file.getSize(),
                     fileOrder
@@ -78,6 +91,35 @@ public class CommentAttachmentService {
         }
 
         return new CommentAttachmentListResponse(responses);
+    }
+
+    private String extractExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf('.');
+
+        if (lastDotIndex == -1 || lastDotIndex == fileName.length() - 1) {
+            return "";
+        }
+
+        return fileName.substring(lastDotIndex);
+    }
+
+    private void saveFile(MultipartFile file, String storedName) {
+        try {
+            Files.createDirectories(COMMENT_UPLOAD_DIR);
+            Path targetPath = COMMENT_UPLOAD_DIR.resolve(storedName);
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new UncheckedIOException("댓글 첨부파일 저장에 실패했습니다.", e);
+        }
+    }
+
+    private void deleteFileIfExists(String storedName) {
+        try {
+            Path targetPath = COMMENT_UPLOAD_DIR.resolve(storedName);
+            Files.deleteIfExists(targetPath);
+        } catch (IOException e) {
+            throw new UncheckedIOException("댓글 첨부파일 삭제에 실패했습니다.", e);
+        }
     }
 
     public CommentAttachmentListResponse getAttachments(Long commentId) {
@@ -111,6 +153,7 @@ public class CommentAttachmentService {
         CommentAttachment attachment = commentAttachmentRepository.findByIdAndCommentId(attachmentId, commentId)
                 .orElseThrow(() -> new EntityNotFoundException("댓글 첨부파일을 찾을 수 없습니다. id=" + attachmentId));
 
+        deleteFileIfExists(attachment.getStoredName());
         commentAttachmentRepository.delete(attachment);
         return new CommentAttachmentDeleteResponse(attachmentId, "댓글 첨부파일 삭제 성공");
     }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
@@ -42,10 +42,11 @@ public class CommentController {
                 getAuthenticatedUserId(principal),
                 request
         );
+        SuccessCode successCode = SuccessCode.COMMENT_201_CREATE_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_CREATE_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     /**
@@ -64,10 +65,11 @@ public class CommentController {
                 getAuthenticatedUserId(principal),
                 request
         );
+        SuccessCode successCode = SuccessCode.COMMENT_201_REPLY_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_REPLY_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     /**
@@ -87,10 +89,11 @@ public class CommentController {
                 getAuthenticatedUserId(principal),
                 request
         );
+        SuccessCode successCode = SuccessCode.COMMENT_200_UPDATE_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_UPDATE_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     /**
@@ -108,19 +111,21 @@ public class CommentController {
                 commentId,
                 getAuthenticatedUserId(principal)
         );
+        SuccessCode successCode = SuccessCode.COMMENT_200_DELETE_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_DELETE_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<SuccessResponse<CommentListResponse>> getComments(@PathVariable Long postId) {
         CommentListResponse response = commentService.getComments(postId);
+        SuccessCode successCode = SuccessCode.COMMENT_200_LIST_SUCCESS;
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(SuccessCode.COMMENT_LIST_SUCCESS, response)
-        );
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.of(successCode, response));
     }
 
 }

--- a/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
@@ -18,22 +18,21 @@ public enum SuccessCode {
     // 신고 관련 성공 코드
     REPORT_SUCCESS(HttpStatus.OK, "REPORT_200", "신고가 정상적으로 접수되었습니다."),
 
-    // 알림 관련 성공 코드
-    NOTIFICATION_LIST_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_LIST", "알림 목록 조회 성공"),
-    NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_READ", "알림 읽음 처리 성공"),
+    // Notification SuccessCode
+    NOTIFICATION_200_LIST_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_LIST_SUCCESS", "알림 목록 조회 성공"),
+    NOTIFICATION_200_READ_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_READ_SUCCESS", "알림 읽음 처리 성공"),
 
+    // CommentAttachment SuccessCode
+    COMMENT_ATTACHMENT_201_UPLOAD_SUCCESS(HttpStatus.CREATED, "COMMENT_ATTACHMENT_201_UPLOAD_SUCCESS", "댓글 첨부파일 업로드 성공"),
+    COMMENT_ATTACHMENT_200_LIST_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_LIST_SUCCESS", "댓글 첨부파일 조회 성공"),
+    COMMENT_ATTACHMENT_200_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_DELETE_SUCCESS", "댓글 첨부파일 삭제 성공"),
 
-    // 댓글 첨부파일 관련 성공 코드
-    COMMENT_ATTACHMENT_UPLOAD_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_UPLOAD", "댓글 첨부파일 업로드 성공"),
-    COMMENT_ATTACHMENT_LIST_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_LIST", "댓글 첨부파일 조회 성공"),
-    COMMENT_ATTACHMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_DELETE", "댓글 첨부파일 삭제 성공"),
-
-    // 댓글 관련 성공 코드
-    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_200_CREATE", "댓글 작성 성공"),
-    COMMENT_REPLY_SUCCESS(HttpStatus.OK, "COMMENT_200_REPLY", "대댓글 작성 성공"),
-    COMMENT_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_200_UPDATE", "댓글 수정 성공"),
-    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_200_DELETE", "댓글 삭제 성공"),
-    COMMENT_LIST_SUCCESS(HttpStatus.OK, "COMMENT_200_LIST", "댓글 목록 조회 성공"),
+    // Comment SuccessCode
+    COMMENT_201_CREATE_SUCCESS(HttpStatus.CREATED, "COMMENT_201_CREATE_SUCCESS", "댓글 작성 성공"),
+    COMMENT_201_REPLY_SUCCESS(HttpStatus.CREATED, "COMMENT_201_REPLY_SUCCESS", "대댓글 작성 성공"),
+    COMMENT_200_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_200_UPDATE_SUCCESS", "댓글 수정 성공"),
+    COMMENT_200_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_200_DELETE_SUCCESS", "댓글 삭제 성공"),
+    COMMENT_200_LIST_SUCCESS(HttpStatus.OK, "COMMENT_200_LIST_SUCCESS", "댓글 목록 조회 성공"),
 
     // 회원 탈퇴 성공 코드
     WITHDRAW_SUCCESS(HttpStatus.OK, "USER_200_WITHDRAW_SUCCESS", "회원 탈퇴가 완료되었습니다.");

--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -7,8 +7,15 @@ type CommentSectionProps = {
     postId: number
 }
 
+type SuccessResponse<T> = {
+    code: string
+    message: string
+    data: T
+}
+
 type CommentAttachmentItem = {
-    attachmentId: number
+    attachmentId?: number
+    id?: number
     fileName: string
     fileUrl: string
     fileType?: string | null
@@ -18,19 +25,64 @@ type CommentAttachmentItem = {
 type CommentItem = {
     commentId: number
     postId: number
+    postTitle?: string
     userId: number
     nickname: string | null
     parentCommentId: number | null
     content: string
     createdAt: string
     updatedAt: string
-    deleted: boolean
+    deleted?: boolean
+    isDeleted?: boolean
     attachments?: CommentAttachmentItem[]
     replies: CommentItem[]
 }
 
 type CommentListResponse = {
     comments: CommentItem[]
+}
+
+function normalizeAttachment(attachment: CommentAttachmentItem): CommentAttachmentItem {
+    return {
+        ...attachment,
+        attachmentId: attachment.attachmentId ?? attachment.id,
+    }
+}
+
+function normalizeComment(comment: CommentItem): CommentItem {
+    return {
+        ...comment,
+        deleted: comment.deleted ?? comment.isDeleted ?? false,
+        attachments: (comment.attachments ?? []).map(normalizeAttachment),
+        replies: (comment.replies ?? []).map(normalizeComment),
+    }
+}
+
+function extractCommentListResponse(responseBody: unknown): CommentListResponse {
+    if (!responseBody || typeof responseBody !== "object") {
+        return { comments: [] }
+    }
+
+    const body = responseBody as
+        | CommentListResponse
+        | SuccessResponse<CommentListResponse>
+        | { data?: CommentListResponse }
+
+    if (Array.isArray((body as CommentListResponse).comments)) {
+        return {
+            comments: ((body as CommentListResponse).comments ?? []).map(normalizeComment),
+        }
+    }
+
+    const nestedComments = (body as SuccessResponse<CommentListResponse>).data?.comments
+
+    if (Array.isArray(nestedComments)) {
+        return {
+            comments: nestedComments.map(normalizeComment),
+        }
+    }
+
+    return { comments: [] }
 }
 
 type CreatedCommentApiResponse = {
@@ -215,7 +267,7 @@ function renderAttachments(attachments: CommentAttachmentItem[] | undefined) {
 
                     return (
                         <div
-                            key={attachment.attachmentId}
+                            key={attachment.attachmentId ?? attachment.id ?? attachment.fileName}
                             className="flex flex-col gap-2 rounded-md border border-border/70 p-3"
                         >
                             {isImage && (
@@ -280,7 +332,8 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                 throw new Error("댓글을 불러오지 못했습니다.")
             }
 
-            const data: CommentListResponse = await response.json()
+            const responseBody = await response.json()
+            const data = extractCommentListResponse(responseBody)
             setComments(sortCommentsByNewest(data.comments ?? []))
         } catch (err) {
             setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
@@ -601,7 +654,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                         type="file"
                         multiple
                         onChange={(event) => {
-                            setNewCommentFiles(Array.from(event.target.files ?? []))
+                            const selectedFiles = Array.from(event.target.files ?? [])
+                            setNewCommentFiles(selectedFiles)
+                            event.target.value = ""
                         }}
                         className="hidden"
                     />
@@ -674,7 +729,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                             </div>
                         ) : (
                             <>
-                                <p className="text-sm text-foreground">{comment.content}</p>
+                                <p className="text-sm text-foreground">
+                                    {comment.deleted ? "삭제된 댓글입니다." : comment.content}
+                                </p>
                                 {renderAttachments(comment.attachments)}
                             </>
                         )}
@@ -748,10 +805,12 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                                             type="file"
                                             multiple
                                             onChange={(event) => {
+                                                const selectedFiles = Array.from(event.target.files ?? [])
                                                 setReplyFiles((prev) => ({
                                                     ...prev,
-                                                    [comment.commentId]: Array.from(event.target.files ?? []),
+                                                    [comment.commentId]: selectedFiles,
                                                 }))
+                                                event.target.value = ""
                                             }}
                                             className="hidden"
                                         />
@@ -821,7 +880,9 @@ export default function CommentSection({ postId }: CommentSectionProps) {
                                             </div>
                                         ) : (
                                             <>
-                                                <p className="text-sm text-foreground">{reply.content}</p>
+                                                <p className="text-sm text-foreground">
+                                                    {reply.deleted ? "삭제된 댓글입니다." : reply.content}
+                                                </p>
                                                 {renderAttachments(reply.attachments)}
                                             </>
                                         )}


### PR DESCRIPTION
## 📌 관련 이슈

related #147 
related #152 

## 🛠️ 작업 내용
- `NotificationController` 응답 형식을 `SuccessCode` 기반 공통 응답으로 정리

- `CommentController` 응답 형식을 `SuccessCode` 기반 공통 응답으로 정리

- `CommentAttachmentController` 응답 형식을 `SuccessCode` 기반 공통 응답으로 정리

- `SuccessCode` 네이밍을 `[DOMAIN]_[HTTP]_[ACTION]_SUCCESS` 규칙으로 통일

- 댓글 첨부파일 업로드 시 `storedName`을 UUID 기반으로 생성하도록 수정

- 댓글 첨부파일 업로드 시 실제 파일이 `uploads/comments/` 경로에 저장되도록 수정

- 댓글 첨부파일 삭제 시 실제 저장 파일도 함께 삭제되도록 수정

- 프론트 `CommentSection.tsx`에서 공통 응답(`SuccessResponse`) 파싱 로직 대응

- 프론트에서 같은 파일을 다시 선택해도 업로드 가능하도록 file input 초기화 처리 추가

- 댓글/대댓글 렌더링 시 삭제 여부 및 첨부파일 렌더링 로직 보정

## 🎯 리뷰 포인트
- 컨트롤러 응답 형식이 모든 댓글/알림 API에서 동일한 패턴으로 적용되었는지

- `SuccessCode` 네이밍과 상태코드(`200`, `201`)가 API 행위와 맞는지

- 댓글 첨부파일 업로드 시 실제 파일 저장 경로와 DB 저장 정보(`storedName`, `fileUrl`)가 일관적인지

- 프론트 `CommentSection.tsx`에서 공통 응답 파싱이 안정적으로 처리되는지

- 같은 파일 재업로드 시 input 초기화 방식이 적절한지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?