### PR TITLE
fix: 댓글 첨부파일 업로드 및 알림 응답 파싱 오류 수정(#163)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentService.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import com.back.devc.domain.interaction.notification.service.NotificationService;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +32,7 @@ public class CommentService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CommentAttachmentService commentAttachmentService;
+    private final NotificationService notificationService;
 
     @Transactional
     public CommentResponse createComment(Long postId, Long loginUserId, CommentCreateRequest request) {
@@ -46,8 +48,8 @@ public class CommentService {
                 null,
                 request.content()
         );
-
         Comment savedComment = commentRepository.save(comment);
+        notificationService.createCommentNotification(postId, loginUserId, savedComment.getId());
         return toResponse(savedComment, post.getTitle(), member.getNickname());
     }
 
@@ -72,8 +74,8 @@ public class CommentService {
                 parentComment.getId(),
                 request.content()
         );
-
         Comment savedReply = commentRepository.save(reply);
+        notificationService.createReplyNotification(parentCommentId, loginUserId, savedReply.getId());
         return toResponse(savedReply, post.getTitle(), member.getNickname());
     }
 

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -1,468 +1,539 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import {useCallback, useEffect, useMemo, useState} from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { Bell, MessageCircle, Heart, UserPlus, Check } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { getAuthSnapshot } from "@/lib/auth-storage"
+import {useRouter} from "next/navigation"
+import {Bell, MessageCircle, Heart, UserPlus, Check} from "lucide-react"
+import {Button} from "@/components/ui/button"
+import {Avatar, AvatarFallback, AvatarImage} from "@/components/ui/avatar"
+import {Tabs, TabsContent, TabsList, TabsTrigger} from "@/components/ui/tabs"
+import {getAuthSnapshot} from "@/lib/auth-storage"
 
 const API_BASE_URL = "http://localhost:8080"
 
 type NotificationType = "comment" | "reply" | "like" | "follow"
 
 type NotificationItem = {
-  notificationId: number
-  userId: number
-  actorUserId: number
-  actorNickname?: string
-  postId: number | null
-  commentId: number | null
-  type: string
-  message: string
-  isRead?: boolean
-  read?: boolean
-  createdAt: string
+    notificationId: number
+    userId: number
+    actorUserId: number
+    actorNickname?: string
+    postId: number | null
+    commentId: number | null
+    type: string
+    message: string
+    isRead?: boolean
+    read?: boolean
+    createdAt: string
 }
 
 type NotificationListResponse = {
-  notifications: NotificationItem[]
+    notifications: NotificationItem[]
+}
+
+type SuccessResponse<T> = {
+    code: string
+    message: string
+    data: T
+}
+
+function extractNotificationListResponse(responseBody: unknown): NotificationListResponse {
+    if (!responseBody || typeof responseBody !== "object") {
+        return {notifications: []}
+    }
+
+    const body = responseBody as
+        | NotificationListResponse
+        | SuccessResponse<NotificationListResponse>
+        | { data?: NotificationListResponse }
+
+    if (Array.isArray((body as NotificationListResponse).notifications)) {
+        return {
+            notifications: ((body as NotificationListResponse).notifications ?? []).map(normalizeNotification),
+        }
+    }
+
+    const nestedNotifications = (body as SuccessResponse<NotificationListResponse>).data?.notifications
+
+    if (Array.isArray(nestedNotifications)) {
+        return {
+            notifications: nestedNotifications.map(normalizeNotification),
+        }
+    }
+
+    return {notifications: []}
 }
 
 async function ensureAuthReady() {
-  if (typeof window === "undefined") {
-    return false
-  }
+    if (typeof window === "undefined") {
+        return false
+    }
 
-  const token = window.localStorage.getItem("accessToken")
-  if (token) {
-    return true
-  }
+    const token = window.localStorage.getItem("accessToken")
+    if (token) {
+        return true
+    }
 
-  try {
-    const response = await fetch(`${API_BASE_URL}/api/users/me`, {
-      method: "GET",
-      credentials: "include",
-      cache: "no-store",
-    })
+    try {
+        const response = await fetch(`${API_BASE_URL}/api/users/me`, {
+            method: "GET",
+            credentials: "include",
+            cache: "no-store",
+        })
 
-    return response.ok
-  } catch {
-    return false
-  }
+        return response.ok
+    } catch {
+        return false
+    }
 }
 
 function normalizeNotification(notification: NotificationItem): NotificationItem {
-  return {
-    ...notification,
-    isRead: notification.isRead ?? notification.read ?? false,
-  }
+    return {
+        ...notification,
+        isRead: notification.isRead ?? notification.read ?? false,
+    }
 }
 
 function mapBackendType(type: string): NotificationType {
-  switch (type.toUpperCase()) {
-    case "COMMENT":
-      return "comment"
-    case "REPLY":
-      return "reply"
-    case "LIKE":
-      return "like"
-    case "FOLLOW":
-      return "follow"
-    default:
-      return "comment"
-  }
+    switch (type.toUpperCase()) {
+        case "COMMENT":
+            return "comment"
+        case "REPLY":
+            return "reply"
+        case "LIKE":
+            return "like"
+        case "FOLLOW":
+            return "follow"
+        case "BOOKMARK":
+            return "like"
+        case "REPORT":
+            return "comment"
+        default:
+            return "comment"
+    }
 }
 
 function getNotificationIcon(type: NotificationType) {
-  switch (type) {
-    case "comment":
-    case "reply":
-      return <MessageCircle className="h-4 w-4" />
-    case "like":
-      return <Heart className="h-4 w-4" />
-    case "follow":
-      return <UserPlus className="h-4 w-4" />
-    default:
-      return <Bell className="h-4 w-4" />
-  }
+    switch (type) {
+        case "comment":
+        case "reply":
+            return <MessageCircle className="h-4 w-4"/>
+        case "like":
+            return <Heart className="h-4 w-4"/>
+        case "follow":
+            return <UserPlus className="h-4 w-4"/>
+        default:
+            return <Bell className="h-4 w-4"/>
+    }
 }
 
 function getNotificationColor(type: NotificationType) {
-  switch (type) {
-    case "comment":
-    case "reply":
-      return "bg-blue-500/20 text-blue-400"
-    case "like":
-      return "bg-red-500/20 text-red-400"
-    case "follow":
-      return "bg-green-500/20 text-green-400"
-    default:
-      return "bg-primary/20 text-primary"
-  }
+    switch (type) {
+        case "comment":
+        case "reply":
+            return "bg-blue-500/20 text-blue-400"
+        case "like":
+            return "bg-red-500/20 text-red-400"
+        case "follow":
+            return "bg-green-500/20 text-green-400"
+        default:
+            return "bg-primary/20 text-primary"
+    }
 }
 
 function dispatchNotificationsUpdated() {
-  if (typeof window === "undefined") {
-    return
-  }
+    if (typeof window === "undefined") {
+        return
+    }
 
-  window.dispatchEvent(new CustomEvent("notifications-updated"))
+    window.dispatchEvent(new CustomEvent("notifications-updated"))
 }
 
 function getAuthHeaders() {
-  if (typeof window === "undefined") {
-    return undefined
-  }
+    if (typeof window === "undefined") {
+        return undefined
+    }
 
-  const token = window.localStorage.getItem("accessToken")
+    const token = window.localStorage.getItem("accessToken")
 
-  if (!token || token === "oauth-cookie-session") {
-    return undefined
-  }
+    if (!token || token === "oauth-cookie-session") {
+        return undefined
+    }
 
-  return {
-    Authorization: `Bearer ${token}`,
-  }
+    return {
+        Authorization: `Bearer ${token}`,
+    }
 }
 
 function formatRelativeDate(createdAt: string) {
-  const date = new Date(createdAt)
+    const date = new Date(createdAt)
 
-  if (Number.isNaN(date.getTime())) {
-    return createdAt
-  }
+    if (Number.isNaN(date.getTime())) {
+        return createdAt
+    }
 
-  const diffMs = Date.now() - date.getTime()
-  const diffMinutes = Math.max(0, Math.floor(diffMs / 1000 / 60))
+    const diffMs = Date.now() - date.getTime()
+    const diffMinutes = Math.max(0, Math.floor(diffMs / 1000 / 60))
 
-  if (diffMinutes < 1) return "방금 전"
-  if (diffMinutes < 60) return `${diffMinutes}분 전`
+    if (diffMinutes < 1) return "방금 전"
+    if (diffMinutes < 60) return `${diffMinutes}분 전`
 
-  const diffHours = Math.floor(diffMinutes / 60)
-  if (diffHours < 24) return `${diffHours}시간 전`
+    const diffHours = Math.floor(diffMinutes / 60)
+    if (diffHours < 24) return `${diffHours}시간 전`
 
-  const diffDays = Math.floor(diffHours / 24)
-  if (diffDays < 7) return `${diffDays}일 전`
+    const diffDays = Math.floor(diffHours / 24)
+    if (diffDays < 7) return `${diffDays}일 전`
 
-  return date.toLocaleString("ko-KR")
+    return date.toLocaleString("ko-KR")
 }
 
 export default function NotificationsPage() {
-  const router = useRouter()
-  const [notifications, setNotifications] = useState<NotificationItem[]>([])
-  const [activeTab, setActiveTab] = useState("all")
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [isAuthReady, setIsAuthReady] = useState(false)
+    const router = useRouter()
+    const [notifications, setNotifications] = useState<NotificationItem[]>([])
+    const [activeTab, setActiveTab] = useState("all")
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+    const [isAuthReady, setIsAuthReady] = useState(false)
 
-  useEffect(() => {
-    let isMounted = true
+    useEffect(() => {
+        let isMounted = true
 
-    const syncAuthState = async () => {
-      const localAuth = getAuthSnapshot()
+        const syncAuthState = async () => {
+            const localAuth = getAuthSnapshot()
 
-      if (localAuth.isLoggedIn) {
-        if (isMounted) {
-          setIsAuthReady(true)
+            if (localAuth.isLoggedIn) {
+                if (isMounted) {
+                    setIsAuthReady(true)
+                }
+                return
+            }
+
+            const readyFromServer = await ensureAuthReady()
+
+            if (!isMounted) {
+                return
+            }
+
+            if (!readyFromServer) {
+                setNotifications([])
+                setIsAuthReady(false)
+                router.replace("/login")
+                return
+            }
+
+            setIsAuthReady(true)
         }
-        return
-      }
 
-      const readyFromServer = await ensureAuthReady()
+        const handleAuthChanged = async () => {
+            setNotifications([])
+            await syncAuthState()
+        }
 
-      if (!isMounted) {
-        return
-      }
+        void syncAuthState()
 
-      if (!readyFromServer) {
-        setNotifications([])
-        setIsAuthReady(false)
-        router.replace("/login")
-        return
-      }
+        window.addEventListener("auth-changed", handleAuthChanged)
+        window.addEventListener("storage", handleAuthChanged)
 
-      setIsAuthReady(true)
+        return () => {
+            isMounted = false
+            window.removeEventListener("auth-changed", handleAuthChanged)
+            window.removeEventListener("storage", handleAuthChanged)
+        }
+    }, [router])
+
+    const loadNotifications = useCallback(async () => {
+        try {
+            setLoading(true)
+            setError(null)
+
+            const response = await fetch(`${API_BASE_URL}/api/notifications`, {
+                cache: "no-store",
+                headers: getAuthHeaders(),
+                credentials: "include",
+            })
+
+            if (!response.ok) {
+                throw new Error("알림 목록을 불러오지 못했습니다.")
+            }
+
+            const responseBody = await response.json()
+            const data = extractNotificationListResponse(responseBody)
+            setNotifications(data.notifications ?? [])
+        } catch (fetchError) {
+            const message =
+                fetchError instanceof Error ? fetchError.message : "알림 요청 중 오류가 발생했습니다."
+            setError(message)
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (!isAuthReady) {
+            return
+        }
+
+        void loadNotifications()
+
+        const handleNotificationsUpdated = () => {
+            void loadNotifications()
+        }
+
+        const handleWindowFocus = () => {
+            void loadNotifications()
+        }
+
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === "visible") {
+                void loadNotifications()
+            }
+        }
+
+        const intervalId = window.setInterval(() => {
+            void loadNotifications()
+        }, 10000)
+
+        window.addEventListener("notifications-updated", handleNotificationsUpdated)
+        window.addEventListener("focus", handleWindowFocus)
+        document.addEventListener("visibilitychange", handleVisibilityChange)
+
+        return () => {
+            window.clearInterval(intervalId)
+            window.removeEventListener("notifications-updated", handleNotificationsUpdated)
+            window.removeEventListener("focus", handleWindowFocus)
+            document.removeEventListener("visibilitychange", handleVisibilityChange)
+        }
+    }, [isAuthReady, loadNotifications])
+
+    const markAllAsRead = async () => {
+        const unreadNotifications = notifications.filter((notification) => !notification.isRead)
+
+        if (unreadNotifications.length === 0) return
+
+        try {
+            setError(null)
+
+            await Promise.all(
+                unreadNotifications.map(async (notification) => {
+                    const response = await fetch(
+                        `${API_BASE_URL}/api/notifications/${notification.notificationId}/read`,
+                        {
+                            method: "PATCH",
+                            headers: getAuthHeaders(),
+                            credentials: "include",
+                        }
+                    )
+
+                    if (!response.ok) {
+                        throw new Error("일부 알림 읽음 처리에 실패했습니다.")
+                    }
+                })
+            )
+
+            await loadNotifications()
+            dispatchNotificationsUpdated()
+        } catch (readError) {
+            const message =
+                readError instanceof Error ? readError.message : "알림 읽음 처리 중 오류가 발생했습니다."
+            setError(message)
+        }
     }
 
-    const handleAuthChanged = async () => {
-      setNotifications([])
-      await syncAuthState()
-    }
+    const markAsRead = async (notificationId: number) => {
+        try {
+            setError(null)
 
-    void syncAuthState()
-
-    window.addEventListener("auth-changed", handleAuthChanged)
-    window.addEventListener("storage", handleAuthChanged)
-
-    return () => {
-      isMounted = false
-      window.removeEventListener("auth-changed", handleAuthChanged)
-      window.removeEventListener("storage", handleAuthChanged)
-    }
-  }, [router])
-
-  const loadNotifications = async () => {
-    try {
-      setLoading(true)
-      setError(null)
-
-      const response = await fetch(`${API_BASE_URL}/api/notifications`, {
-        cache: "no-store",
-        headers: getAuthHeaders(),
-        credentials: "include",
-      })
-
-      if (!response.ok) {
-        throw new Error("알림 목록을 불러오지 못했습니다.")
-      }
-
-      const data: NotificationListResponse = await response.json()
-      setNotifications(data.notifications.map(normalizeNotification))
-    } catch (fetchError) {
-      const message =
-        fetchError instanceof Error ? fetchError.message : "알림 요청 중 오류가 발생했습니다."
-      setError(message)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (!isAuthReady) {
-      return
-    }
-
-    void loadNotifications()
-  }, [isAuthReady])
-
-  const markAllAsRead = async () => {
-    const unreadNotifications = notifications.filter((notification) => !notification.isRead)
-
-    if (unreadNotifications.length === 0) return
-
-    try {
-      setError(null)
-
-      await Promise.all(
-        unreadNotifications.map(async (notification) => {
-          const response = await fetch(
-              `${API_BASE_URL}/api/notifications/${notification.notificationId}/read`,
-              {
+            const response = await fetch(`${API_BASE_URL}/api/notifications/${notificationId}/read`, {
                 method: "PATCH",
                 headers: getAuthHeaders(),
                 credentials: "include",
-              }
-          )
+            })
 
-          if (!response.ok) {
-            throw new Error("일부 알림 읽음 처리에 실패했습니다.")
-          }
-        })
-      )
+            if (!response.ok) {
+                throw new Error("알림 읽음 처리에 실패했습니다.")
+            }
 
-      await loadNotifications()
-      dispatchNotificationsUpdated()
-    } catch (readError) {
-      const message =
-        readError instanceof Error ? readError.message : "알림 읽음 처리 중 오류가 발생했습니다."
-      setError(message)
+            await loadNotifications()
+            dispatchNotificationsUpdated()
+        } catch (readError) {
+            const message =
+                readError instanceof Error ? readError.message : "알림 읽음 처리 중 오류가 발생했습니다."
+            setError(message)
+        }
     }
-  }
 
-  const markAsRead = async (notificationId: number) => {
-    try {
-      setError(null)
+    const unreadCount = notifications.filter((notification) => !notification.isRead).length
 
-      const response = await fetch(`${API_BASE_URL}/api/notifications/${notificationId}/read`, {
-        method: "PATCH",
-        headers: getAuthHeaders(),
-        credentials: "include",
-      })
-
-      if (!response.ok) {
-        throw new Error("알림 읽음 처리에 실패했습니다.")
-      }
-
-      await loadNotifications()
-      dispatchNotificationsUpdated()
-    } catch (readError) {
-      const message =
-        readError instanceof Error ? readError.message : "알림 읽음 처리 중 오류가 발생했습니다."
-      setError(message)
-    }
-  }
-
-  const unreadCount = notifications.filter((notification) => !notification.isRead).length
-
-  const commentNotifications = useMemo(
-    () =>
-      notifications.filter((notification) => {
-        const mappedType = mapBackendType(notification.type)
-        return mappedType === "comment" || mappedType === "reply"
-      }),
-    [notifications]
-  )
-
-  const likeNotifications = useMemo(
-    () => notifications.filter((notification) => mapBackendType(notification.type) === "like"),
-    [notifications]
-  )
-
-  const getFilteredNotifications = () => {
-    switch (activeTab) {
-      case "comments":
-        return commentNotifications
-      case "likes":
-        return likeNotifications
-      default:
-        return notifications
-    }
-  }
-
-  if (!isAuthReady) {
-    return null
-  }
-
-  return (
-    <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
-      <div className="mb-8 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-            <Bell className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">알림</h1>
-            {unreadCount > 0 ? (
-              <p className="text-sm text-muted-foreground">읽지 않은 알림 {unreadCount}개</p>
-            ) : (
-              <p className="text-sm text-muted-foreground">모든 알림을 확인했어요</p>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => void loadNotifications()}>
-            새로고침
-          </Button>
-          {unreadCount > 0 && (
-            <Button variant="outline" onClick={() => void markAllAsRead()} className="gap-2">
-              <Check className="h-4 w-4" />
-              모두 읽음
-            </Button>
-          )}
-        </div>
-      </div>
-
-      {error ? (
-        <div className="mb-6 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
-        </div>
-      ) : null}
-
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="mb-6 w-full justify-start bg-secondary">
-          <TabsTrigger
-            value="all"
-            className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
-          >
-            전체
-          </TabsTrigger>
-          <TabsTrigger
-            value="comments"
-            className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
-          >
-            <MessageCircle className="h-4 w-4" />
-            댓글
-          </TabsTrigger>
-          <TabsTrigger
-            value="likes"
-            className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
-          >
-            <Heart className="h-4 w-4" />
-            좋아요
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value={activeTab} className="mt-0">
-          {loading ? (
-            <div className="rounded-lg border border-border bg-card p-12 text-center text-sm text-muted-foreground">
-              알림을 불러오는 중입니다...
-            </div>
-          ) : getFilteredNotifications().length > 0 ? (
-            <div className="space-y-2">
-              {getFilteredNotifications().map((notification) => {
+    const commentNotifications = useMemo(
+        () =>
+            notifications.filter((notification) => {
                 const mappedType = mapBackendType(notification.type)
+                return mappedType === "comment" || mappedType === "reply"
+            }),
+        [notifications]
+    )
 
-                return (
-                  <div
-                    key={notification.notificationId}
-                    className={`group flex items-start gap-4 rounded-lg border border-border p-4 transition-colors hover:bg-card ${
-                      !notification.isRead ? "bg-primary/5" : "bg-card"
-                    }`}
-                  >
-                    <div
-                      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${getNotificationColor(
-                        mappedType
-                      )}`}
+    const likeNotifications = useMemo(
+        () => notifications.filter((notification) => mapBackendType(notification.type) === "like"),
+        [notifications]
+    )
+
+    const getFilteredNotifications = () => {
+        switch (activeTab) {
+            case "comments":
+                return commentNotifications
+            case "likes":
+                return likeNotifications
+            default:
+                return notifications
+        }
+    }
+
+    if (!isAuthReady) {
+        return null
+    }
+
+    return (
+        <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mb-8 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+                        <Bell className="h-5 w-5 text-primary"/>
+                    </div>
+                    <div>
+                        <h1 className="text-3xl font-bold text-foreground">알림</h1>
+                        {unreadCount > 0 ? (
+                            <p className="text-sm text-muted-foreground">읽지 않은 알림 {unreadCount}개</p>
+                        ) : (
+                            <p className="text-sm text-muted-foreground">모든 알림을 확인했어요</p>
+                        )}
+                    </div>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Button variant="outline" onClick={() => void loadNotifications()}>
+                        새로고침
+                    </Button>
+                    {unreadCount > 0 && (
+                        <Button variant="outline" onClick={() => void markAllAsRead()} className="gap-2">
+                            <Check className="h-4 w-4"/>
+                            모두 읽음
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            {error ? (
+                <div
+                    className="mb-6 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {error}
+                </div>
+            ) : null}
+
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+                <TabsList className="mb-6 w-full justify-start bg-secondary">
+                    <TabsTrigger
+                        value="all"
+                        className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
                     >
-                      {getNotificationIcon(mappedType)}
-                    </div>
+                        전체
+                    </TabsTrigger>
+                    <TabsTrigger
+                        value="comments"
+                        className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
+                    >
+                        <MessageCircle className="h-4 w-4"/>
+                        댓글
+                    </TabsTrigger>
+                    <TabsTrigger
+                        value="likes"
+                        className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
+                    >
+                        <Heart className="h-4 w-4"/>
+                        좋아요
+                    </TabsTrigger>
+                </TabsList>
 
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-start gap-2">
-                        <Avatar className="h-6 w-6">
-                          <AvatarImage
-                            src={undefined}
-                            alt={notification.actorNickname ?? `${notification.actorUserId}번 사용자`}
-                          />
-                          <AvatarFallback className="bg-secondary text-xs text-secondary-foreground">
-                            {notification.actorNickname?.trim()?.slice(0, 2) || `U${notification.actorUserId}`}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="flex-1">
-                          <p className="text-sm text-foreground">{notification.message}</p>
-                          {notification.postId ? (
-                            <Link
-                              href={`/posts/${notification.postId}`}
-                              className="mt-1 line-clamp-1 text-sm text-primary hover:underline"
-                            >
-                              게시글로 이동
-                            </Link>
-                          ) : null}
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            {formatRelativeDate(notification.createdAt)}
-                          </p>
+                <TabsContent value={activeTab} className="mt-0">
+                    {loading ? (
+                        <div
+                            className="rounded-lg border border-border bg-card p-12 text-center text-sm text-muted-foreground">
+                            알림을 불러오는 중입니다...
                         </div>
-                      </div>
-                    </div>
+                    ) : getFilteredNotifications().length > 0 ? (
+                        <div className="space-y-2">
+                            {getFilteredNotifications().map((notification) => {
+                                const mappedType = mapBackendType(notification.type)
 
-                    <div className="flex items-center gap-2 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
-                      {!notification.isRead && <div className="h-2 w-2 rounded-full bg-primary" />}
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={notification.isRead}
-                        onClick={() => void markAsRead(notification.notificationId)}
-                      >
-                        읽음 처리
-                      </Button>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          ) : (
-            <div className="rounded-lg border border-border bg-card p-12 text-center">
-              <Bell className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-              <h3 className="mb-2 text-lg font-semibold text-foreground">알림이 없습니다</h3>
-              <p className="text-sm text-muted-foreground">새로운 알림이 오면 여기에 표시됩니다</p>
-            </div>
-          )}
-        </TabsContent>
-      </Tabs>
-    </div>
-  )
+                                return (
+                                    <div
+                                        key={notification.notificationId}
+                                        className={`group flex items-start gap-4 rounded-lg border border-border p-4 transition-colors hover:bg-card ${
+                                            !notification.isRead ? "bg-primary/5" : "bg-card"
+                                        }`}
+                                    >
+                                        <div
+                                            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${getNotificationColor(
+                                                mappedType
+                                            )}`}
+                                        >
+                                            {getNotificationIcon(mappedType)}
+                                        </div>
+
+                                        <div className="min-w-0 flex-1">
+                                            <div className="flex items-start gap-2">
+                                                <Avatar className="h-6 w-6">
+                                                    <AvatarImage
+                                                        src={undefined}
+                                                        alt={notification.actorNickname ?? `${notification.actorUserId}번 사용자`}
+                                                    />
+                                                    <AvatarFallback
+                                                        className="bg-secondary text-xs text-secondary-foreground">
+                                                        {notification.actorNickname?.trim()?.slice(0, 2) || `U${notification.actorUserId}`}
+                                                    </AvatarFallback>
+                                                </Avatar>
+                                                <div className="flex-1">
+                                                    <p className="text-sm text-foreground">{notification.message}</p>
+                                                    {notification.postId ? (
+                                                        <Link
+                                                            href={`/posts/${notification.postId}`}
+                                                            className="mt-1 line-clamp-1 text-sm text-primary hover:underline"
+                                                        >
+                                                            게시글로 이동
+                                                        </Link>
+                                                    ) : null}
+                                                    <p className="mt-1 text-xs text-muted-foreground">
+                                                        {formatRelativeDate(notification.createdAt)}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div
+                                            className="flex items-center gap-2 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
+                                            {!notification.isRead && <div className="h-2 w-2 rounded-full bg-primary"/>}
+                                            <Button
+                                                type="button"
+                                                variant="outline"
+                                                size="sm"
+                                                disabled={notification.isRead}
+                                                onClick={() => void markAsRead(notification.notificationId)}
+                                            >
+                                                읽음 처리
+                                            </Button>
+                                        </div>
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    ) : (
+                        <div className="rounded-lg border border-border bg-card p-12 text-center">
+                            <Bell className="mx-auto mb-4 h-12 w-12 text-muted-foreground"/>
+                            <h3 className="mb-2 text-lg font-semibold text-foreground">알림이 없습니다</h3>
+                            <p className="text-sm text-muted-foreground">새로운 알림이 오면 여기에 표시됩니다</p>
+                        </div>
+                    )}
+                </TabsContent>
+            </Tabs>
+        </div>
+    )
 }

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -1,397 +1,405 @@
 ﻿"use client"
 
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
-import { Bell, Search, User, Menu, X, PenSquare, Code2 } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import {useRouter} from "next/navigation"
+import {useEffect, useState} from "react"
+import {Bell, Search, User, Menu, X, PenSquare, Code2} from "lucide-react"
+import {Button} from "@/components/ui/button"
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
-  AUTH_CHANGED_EVENT,
-  clearLoginSession,
-  getAccessToken,
-  getAuthSnapshot,
-  persistLoginSession,
+    AUTH_CHANGED_EVENT,
+    clearLoginSession,
+    getAccessToken,
+    getAuthSnapshot,
+    persistLoginSession,
 } from "@/lib/auth-storage"
 
 const categories = [
-  { name: "IT 기술 정보", href: "/category/tech" },
-  { name: "취업 시장 정보", href: "/category/job-market" },
-  { name: "개발 트렌드", href: "/category/trend" },
-  { name: "자유 주제", href: "/category/free" },
+    {name: "IT 기술 정보", href: "/category/tech"},
+    {name: "취업 시장 정보", href: "/category/job-market"},
+    {name: "개발 트렌드", href: "/category/trend"},
+    {name: "자유 주제", href: "/category/free"},
 ]
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
 
 type HeaderNotificationItem = {
-  notificationId: number
-  isRead?: boolean
-  read?: boolean
+    notificationId: number
+    isRead?: boolean
+    read?: boolean
 }
 
 type HeaderNotificationListResponse = {
-  notifications: HeaderNotificationItem[]
+    notifications: HeaderNotificationItem[]
 }
 
 type SuccessResponse<T> = {
-  code?: string
-  message?: string
-  timestamp?: string
-  data?: T
+    code?: string
+    message?: string
+    timestamp?: string
+    data?: T
 }
 
 type MeResponse = {
-  userId?: number
-  email?: string
-  nickname?: string
-  role?: string
-  status?: string
+    userId?: number
+    email?: string
+    nickname?: string
+    role?: string
+    status?: string
 }
 
 function isNotificationUnread(notification: HeaderNotificationItem) {
-  return !(notification.isRead ?? notification.read ?? false)
+    return !(notification.isRead ?? notification.read ?? false)
 }
 
 export function Header() {
-  const router = useRouter()
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [hasUnreadNotifications, setHasUnreadNotifications] = useState(false)
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
-  const [nickname, setNickname] = useState("")
+    const router = useRouter()
+    const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+    const [hasUnreadNotifications, setHasUnreadNotifications] = useState(false)
+    const [isLoggedIn, setIsLoggedIn] = useState(false)
+    const [nickname, setNickname] = useState("")
 
-  useEffect(() => {
-    const syncAuthState = () => {
-      const auth = getAuthSnapshot()
-      setIsLoggedIn(auth.isLoggedIn)
-      setNickname(auth.nickname ?? "")
-    }
-
-    const syncAuthFromServer = async () => {
-      try {
-        const res = await fetch(`${API_BASE_URL}/api/users/me`, {
-          method: "GET",
-          credentials: "include",
-          cache: "no-store",
-        })
-
-        if (res.ok) {
-          const body = (await res.json()) as SuccessResponse<MeResponse>
-          const me = body?.data
-
-          if (me?.email || me?.nickname) {
-            persistLoginSession(
-              undefined,
-              me?.nickname ?? null,
-              me?.email ?? null
-            )
-          }
-        } else if (res.status === 401) {
-          clearLoginSession()
+    useEffect(() => {
+        const syncAuthState = () => {
+            const auth = getAuthSnapshot()
+            setIsLoggedIn(auth.isLoggedIn)
+            setNickname(auth.nickname ?? "")
         }
-      } catch {
-        // 네트워크 오류 시에는 기존 local 상태 유지
-      } finally {
+
+        const syncAuthFromServer = async () => {
+            try {
+                const res = await fetch(`${API_BASE_URL}/api/users/me`, {
+                    method: "GET",
+                    credentials: "include",
+                    cache: "no-store",
+                })
+
+                if (res.ok) {
+                    const body = (await res.json()) as SuccessResponse<MeResponse>
+                    const me = body?.data
+
+                    if (me?.email || me?.nickname) {
+                        persistLoginSession(
+                            undefined,
+                            me?.nickname ?? null,
+                            me?.email ?? null
+                        )
+                    }
+                } else if (res.status === 401) {
+                    clearLoginSession()
+                }
+            } catch {
+                // 네트워크 오류 시에는 기존 local 상태 유지
+            } finally {
+                syncAuthState()
+            }
+        }
+
         syncAuthState()
-      }
-    }
+        void syncAuthFromServer()
 
-    syncAuthState()
-    void syncAuthFromServer()
-
-    const handleStorage = () => {
-      syncAuthState()
-    }
-
-    window.addEventListener("storage", handleStorage)
-    window.addEventListener(AUTH_CHANGED_EVENT, handleStorage as EventListener)
-
-    return () => {
-      window.removeEventListener("storage", handleStorage)
-      window.removeEventListener(AUTH_CHANGED_EVENT, handleStorage as EventListener)
-    }
-  }, [])
-
-  const handleLogout = async () => {
-    try {
-      await fetch(`${API_BASE_URL}/api/auth/logout`, {
-        method: "POST",
-        credentials: "include",
-      })
-    } catch {
-      // 로그아웃 API 실패여도 로컬 세션은 정리
-    } finally {
-      clearLoginSession()
-      setMobileMenuOpen(false)
-      router.push("/")
-      router.refresh()
-    }
-  }
-
-  useEffect(() => {
-    let isMounted = true
-    const loadNotifications = async () => {
-      const auth = getAuthSnapshot()
-
-      if (!auth.isLoggedIn) {
-        if (isMounted) {
-          setHasUnreadNotifications(false)
+        const handleStorage = () => {
+            syncAuthState()
         }
-        return
-      }
-      try {
-        const accessToken = getAccessToken()
-        const headers = accessToken
-          ? { Authorization: `Bearer ${accessToken}` }
-          : undefined
 
-        const response = await fetch(`${API_BASE_URL}/api/notifications`, {
-          cache: "no-store",
-          credentials: "include",
-          headers,
-        })
+        window.addEventListener("storage", handleStorage)
+        window.addEventListener(AUTH_CHANGED_EVENT, handleStorage as EventListener)
 
-        if (!response.ok) {
-          if (isMounted) {
+        return () => {
+            window.removeEventListener("storage", handleStorage)
+            window.removeEventListener(AUTH_CHANGED_EVENT, handleStorage as EventListener)
+        }
+    }, [])
+
+    const handleLogout = async () => {
+        try {
+            await fetch(`${API_BASE_URL}/api/auth/logout`, {
+                method: "POST",
+                credentials: "include",
+            })
+        } catch {
+            // 로그아웃 API 실패여도 로컬 세션은 정리
+        } finally {
+            clearLoginSession()
+            setMobileMenuOpen(false)
+            router.push("/")
+            router.refresh()
+        }
+    }
+
+    useEffect(() => {
+        let isMounted = true
+        const loadNotifications = async () => {
+            const auth = getAuthSnapshot()
+
+            if (!auth.isLoggedIn) {
+                if (isMounted) {
+                    setHasUnreadNotifications(false)
+                }
+                return
+            }
+            try {
+                const accessToken = getAccessToken()
+                const headers = accessToken
+                    ? {Authorization: `Bearer ${accessToken}`}
+                    : undefined
+
+                const response = await fetch(`${API_BASE_URL}/api/notifications`, {
+                    cache: "no-store",
+                    credentials: "include",
+                    headers,
+                })
+
+                if (!response.ok) {
+                    if (isMounted) {
+                        setHasUnreadNotifications(false)
+                    }
+                    return
+                }
+
+                const body = (await response.json()) as SuccessResponse<HeaderNotificationListResponse>
+                const notifications = body?.data?.notifications ?? []
+
+                if (!isMounted) {
+                    return
+                }
+
+                setHasUnreadNotifications(notifications.some(isNotificationUnread))
+            } catch {
+                if (isMounted) {
+                    setHasUnreadNotifications(false)
+                }
+            }
+        }
+
+        const handleNotificationsUpdated = () => {
+            if (isLoggedIn) {
+                void loadNotifications()
+            } else {
+                setHasUnreadNotifications(false)
+            }
+        }
+
+        if (isLoggedIn) {
+            void loadNotifications()
+        } else {
             setHasUnreadNotifications(false)
-          }
-          return
         }
+        window.addEventListener("notifications-updated", handleNotificationsUpdated)
 
-        const data: HeaderNotificationListResponse = await response.json()
-
-        if (!isMounted) {
-          return
+        return () => {
+            isMounted = false
+            window.removeEventListener("notifications-updated", handleNotificationsUpdated)
         }
+    }, [isLoggedIn])
 
-        setHasUnreadNotifications(data.notifications.some(isNotificationUnread))
-      } catch {
-        if (isMounted) {
-          setHasUnreadNotifications(false)
-        }
-      }
-    }
+    return (
+        <header
+            className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+                <Link href="/" className="flex items-center gap-2">
+                    <Code2 className="h-7 w-7 text-primary"/>
+                    <span className="text-xl font-bold text-foreground">DevConnect</span>
+                </Link>
 
-    const handleNotificationsUpdated = () => {
-      if (isLoggedIn) {
-        void loadNotifications()
-      } else {
-        setHasUnreadNotifications(false)
-      }
-    }
+                <nav className="hidden items-center gap-6 md:flex">
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" className="text-muted-foreground hover:text-foreground">
+                                카테고리
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="start" className="w-48">
+                            {categories.map((category) => (
+                                <DropdownMenuItem key={category.name} asChild>
+                                    <Link href={category.href}>{category.name}</Link>
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
 
-    if (isLoggedIn) {
-      void loadNotifications()
-    } else {
-      setHasUnreadNotifications(false)
-    }
-    window.addEventListener("notifications-updated", handleNotificationsUpdated)
+                    <Link href="/popular"
+                          className="text-sm text-muted-foreground transition-colors hover:text-foreground">
+                        인기글
+                    </Link>
+                    <Link href="/latest"
+                          className="text-sm text-muted-foreground transition-colors hover:text-foreground">
+                        최신글
+                    </Link>
+                    <Link href="/feed"
+                          className="text-sm text-muted-foreground transition-colors hover:text-foreground">
+                        북마크
+                    </Link>
+                </nav>
 
-    return () => {
-      isMounted = false
-      window.removeEventListener("notifications-updated", handleNotificationsUpdated)
-    }
-  }, [isLoggedIn])
+                <div className="flex items-center gap-2">
+                    <Link href="/search">
+                        <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-foreground">
+                            <Search className="h-5 w-5"/>
+                            <span className="sr-only">검색</span>
+                        </Button>
+                    </Link>
 
-  return (
-    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-        <Link href="/" className="flex items-center gap-2">
-          <Code2 className="h-7 w-7 text-primary" />
-          <span className="text-xl font-bold text-foreground">DevConnect</span>
-        </Link>
+                    <Link href={isLoggedIn ? "/notifications" : "/login"}>
+                        <Button variant="ghost" size="icon"
+                                className="relative text-muted-foreground hover:text-foreground">
+                            <Bell className="h-5 w-5"/>
+                            {hasUnreadNotifications ? (
+                                <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary"/>
+                            ) : null}
+                            <span className="sr-only">알림</span>
+                        </Button>
+                    </Link>
 
-        <nav className="hidden items-center gap-6 md:flex">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="text-muted-foreground hover:text-foreground">
-                카테고리
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-48">
-              {categories.map((category) => (
-                <DropdownMenuItem key={category.name} asChild>
-                  <Link href={category.href}>{category.name}</Link>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                    <Link href={isLoggedIn ? "/write" : "/login"} className="hidden sm:block">
+                        <Button className="gap-2 bg-primary text-primary-foreground hover:bg-primary/90">
+                            <PenSquare className="h-4 w-4"/>
+                            글 쓰기
+                        </Button>
+                    </Link>
 
-          <Link href="/popular" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            인기글
-          </Link>
-          <Link href="/latest" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            최신글
-          </Link>
-          <Link href="/feed" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            북마크
-          </Link>
-        </nav>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" className="gap-2 text-muted-foreground hover:text-foreground">
+                                <User className="h-5 w-5"/>
+                                {isLoggedIn ? (
+                                    <span className="max-w-24 truncate text-sm">{nickname || "사용자"}</span>
+                                ) : null}
+                                <span className="sr-only">마이페이지</span>
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-48">
+                            {isLoggedIn ? (
+                                <>
+                                    <DropdownMenuItem disabled className="font-medium">
+                                        {nickname || "사용자"}
+                                    </DropdownMenuItem>
+                                    <DropdownMenuSeparator/>
+                                </>
+                            ) : null}
 
-        <div className="flex items-center gap-2">
-          <Link href="/search">
-            <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-foreground">
-              <Search className="h-5 w-5" />
-              <span className="sr-only">검색</span>
-            </Button>
-          </Link>
+                            <DropdownMenuItem asChild>
+                                <Link href={isLoggedIn ? "/mypage" : "/login"}>마이페이지</Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link href={isLoggedIn ? "/mypage/posts" : "/login"}>내 글 보기</Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link href={isLoggedIn ? "/mypage/edit" : "/login"}>프로필 수정</Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator/>
 
-          <Link href={isLoggedIn ? "/notifications" : "/login"}>
-            <Button variant="ghost" size="icon" className="relative text-muted-foreground hover:text-foreground">
-              <Bell className="h-5 w-5" />
-              {hasUnreadNotifications ? (
-                <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary" />
-              ) : null}
-              <span className="sr-only">알림</span>
-            </Button>
-          </Link>
+                            {isLoggedIn ? (
+                                <DropdownMenuItem onSelect={() => void handleLogout()}>로그아웃</DropdownMenuItem>
+                            ) : (
+                                <>
+                                    <DropdownMenuItem asChild>
+                                        <Link href="/login">로그인</Link>
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem asChild>
+                                        <Link href="/signup">회원가입</Link>
+                                    </DropdownMenuItem>
+                                </>
+                            )}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
 
-          <Link href={isLoggedIn ? "/write" : "/login"} className="hidden sm:block">
-            <Button className="gap-2 bg-primary text-primary-foreground hover:bg-primary/90">
-              <PenSquare className="h-4 w-4" />
-              글 쓰기
-            </Button>
-          </Link>
-
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="gap-2 text-muted-foreground hover:text-foreground">
-                <User className="h-5 w-5" />
-                {isLoggedIn ? (
-                  <span className="max-w-24 truncate text-sm">{nickname || "사용자"}</span>
-                ) : null}
-                <span className="sr-only">마이페이지</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              {isLoggedIn ? (
-                <>
-                  <DropdownMenuItem disabled className="font-medium">
-                    {nickname || "사용자"}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                </>
-              ) : null}
-
-              <DropdownMenuItem asChild>
-                <Link href={isLoggedIn ? "/mypage" : "/login"}>마이페이지</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href={isLoggedIn ? "/mypage/posts" : "/login"}>내 글 보기</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href={isLoggedIn ? "/mypage/edit" : "/login"}>프로필 수정</Link>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-
-              {isLoggedIn ? (
-                <DropdownMenuItem onSelect={() => void handleLogout()}>로그아웃</DropdownMenuItem>
-              ) : (
-                <>
-                  <DropdownMenuItem asChild>
-                    <Link href="/login">로그인</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link href="/signup">회원가입</Link>
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-muted-foreground hover:text-foreground md:hidden"
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-          >
-            {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-            <span className="sr-only">메뉴</span>
-          </Button>
-        </div>
-      </div>
-
-      {mobileMenuOpen && (
-        <div className="border-t border-border bg-background md:hidden">
-          <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6">
-            <nav className="flex flex-col gap-4">
-              <Link
-                href="/popular"
-                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                인기글
-              </Link>
-              <Link
-                href="/latest"
-                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                최신글
-              </Link>
-              <Link
-                href="/feed"
-                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                피드
-              </Link>
-
-              <div className="border-t border-border pt-4">
-                <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">카테고리</p>
-                <div className="flex flex-wrap gap-2">
-                  {categories.map((category) => (
-                    <Link
-                      key={category.name}
-                      href={category.href}
-                      className="rounded-md bg-secondary px-3 py-1.5 text-sm text-secondary-foreground transition-colors hover:bg-secondary/80"
-                      onClick={() => setMobileMenuOpen(false)}
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-foreground md:hidden"
+                        onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                     >
-                      {category.name}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-
-              <Link href={isLoggedIn ? "/write" : "/login"} onClick={() => setMobileMenuOpen(false)}>
-                <Button className="w-full gap-2 bg-primary text-primary-foreground hover:bg-primary/90">
-                  <PenSquare className="h-4 w-4" />
-                  글 쓰기
-                </Button>
-              </Link>
-
-              <div className="border-t border-border pt-4">
-                {isLoggedIn ? (
-                  <>
-                    <p className="mb-3 text-sm text-foreground">{nickname || "사용자"}님</p>
-                    <Button type="button" variant="outline" className="w-full" onClick={() => void handleLogout()}>
-                      로그아웃
+                        {mobileMenuOpen ? <X className="h-5 w-5"/> : <Menu className="h-5 w-5"/>}
+                        <span className="sr-only">메뉴</span>
                     </Button>
-                  </>
-                ) : (
-                  <div className="flex gap-2">
-                    <Link href="/login" className="flex-1" onClick={() => setMobileMenuOpen(false)}>
-                      <Button type="button" variant="outline" className="w-full">
-                        로그인
-                      </Button>
-                    </Link>
-                    <Link href="/signup" className="flex-1" onClick={() => setMobileMenuOpen(false)}>
-                      <Button type="button" className="w-full">
-                        회원가입
-                      </Button>
-                    </Link>
-                  </div>
-                )}
-              </div>
-            </nav>
-          </div>
-        </div>
-      )}
-    </header>
-  )
+                </div>
+            </div>
+
+            {mobileMenuOpen && (
+                <div className="border-t border-border bg-background md:hidden">
+                    <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6">
+                        <nav className="flex flex-col gap-4">
+                            <Link
+                                href="/popular"
+                                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                onClick={() => setMobileMenuOpen(false)}
+                            >
+                                인기글
+                            </Link>
+                            <Link
+                                href="/latest"
+                                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                onClick={() => setMobileMenuOpen(false)}
+                            >
+                                최신글
+                            </Link>
+                            <Link
+                                href="/feed"
+                                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                onClick={() => setMobileMenuOpen(false)}
+                            >
+                                피드
+                            </Link>
+
+                            <div className="border-t border-border pt-4">
+                                <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">카테고리</p>
+                                <div className="flex flex-wrap gap-2">
+                                    {categories.map((category) => (
+                                        <Link
+                                            key={category.name}
+                                            href={category.href}
+                                            className="rounded-md bg-secondary px-3 py-1.5 text-sm text-secondary-foreground transition-colors hover:bg-secondary/80"
+                                            onClick={() => setMobileMenuOpen(false)}
+                                        >
+                                            {category.name}
+                                        </Link>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <Link href={isLoggedIn ? "/write" : "/login"} onClick={() => setMobileMenuOpen(false)}>
+                                <Button className="w-full gap-2 bg-primary text-primary-foreground hover:bg-primary/90">
+                                    <PenSquare className="h-4 w-4"/>
+                                    글 쓰기
+                                </Button>
+                            </Link>
+
+                            <div className="border-t border-border pt-4">
+                                {isLoggedIn ? (
+                                    <>
+                                        <p className="mb-3 text-sm text-foreground">{nickname || "사용자"}님</p>
+                                        <Button type="button" variant="outline" className="w-full"
+                                                onClick={() => void handleLogout()}>
+                                            로그아웃
+                                        </Button>
+                                    </>
+                                ) : (
+                                    <div className="flex gap-2">
+                                        <Link href="/login" className="flex-1" onClick={() => setMobileMenuOpen(false)}>
+                                            <Button type="button" variant="outline" className="w-full">
+                                                로그인
+                                            </Button>
+                                        </Link>
+                                        <Link href="/signup" className="flex-1"
+                                              onClick={() => setMobileMenuOpen(false)}>
+                                            <Button type="button" className="w-full">
+                                                회원가입
+                                            </Button>
+                                        </Link>
+                                    </div>
+                                )}
+                            </div>
+                        </nav>
+                    </div>
+                </div>
+            )}
+        </header>
+    )
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #163 

## 🛠️ 작업 내용
- 댓글/대댓글 작성 시 `NotificationService` 호출을 추가해 알림이 생성되도록 수정

- `NotificationController`, `CommentController`, `CommentAttachmentController` 응답 형식을 `SuccessCode` 기반 공통 응답으로 통일

- `SuccessCode` 네이밍을 `[DOMAIN]_[HTTP]_[ACTION]_SUCCESS` 규칙으로 정리

- 댓글 첨부파일 업로드 시 `storedName`을 UUID 기반으로 생성하도록 수정

- 댓글 첨부파일 업로드 시 실제 파일을 `uploads/comments/` 경로에 저장하도록 수정

- 댓글 첨부파일 삭제 시 실제 저장 파일도 함께 삭제되도록 수정

- 프론트 `CommentSection.tsx`에서 공통 응답(`SuccessResponse`) 파싱 로직 대응

- 같은 파일을 다시 선택해도 업로드 가능하도록 file input 초기화 처리 추가

- 알림 페이지(`frontend/app/notifications/page.tsx`)에서 공통 응답 형식에 맞게 알림 목록 파싱 로직 수정

- 헤더(`frontend/components/layout/header.tsx`)에서 공통 응답 형식에 맞게 unread 알림 여부 파싱 로직 수정

- 알림 페이지에서 `Cannot read properties of undefined (reading 'map')` 오류가 발생하지 않도록 방어 로직 추가

## 🎯 리뷰 포인트
- 댓글/대댓글 작성 시 알림 생성 호출이 적절한 위치에서 수행되는지

- 컨트롤러 응답 형식이 댓글/알림/첨부파일 도메인에서 동일한 패턴으로 적용되었는지

- `SuccessCode` 상태코드(`200`, `201`)와 네이밍 규칙이 API 행위와 맞는지

- 댓글 첨부파일 업로드 시 실제 파일 저장 경로와 DB 메타데이터(`storedName`, `fileUrl`)가 일관적인지

- 알림 페이지와 헤더에서 공통 응답 파싱이 안정적으로 처리되는지

- 같은 파일 재업로드 시 프론트 input 초기화 방식이 적절한지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?