### PR TITLE
fix: 북마크 생성 시 알림 발송 제거(#165)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/service/BookmarkService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/service/BookmarkService.java
@@ -4,7 +4,6 @@ import com.back.devc.domain.interaction.bookmark.dto.BookmarkResponse;
 import com.back.devc.domain.interaction.bookmark.dto.BookmarkedPostResponse;
 import com.back.devc.domain.interaction.bookmark.entity.Bookmark;
 import com.back.devc.domain.interaction.bookmark.repository.BookmarkRepository;
-import com.back.devc.domain.interaction.notification.service.NotificationService;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.domain.member.member.util.MemberDisplayUtil;
@@ -25,7 +24,6 @@ public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
-    private final NotificationService notificationService;
 
     @Transactional
     public BookmarkResponse createBookmark(Long userId, Long postId) {
@@ -45,8 +43,6 @@ public class BookmarkService {
 
         Bookmark bookmark = new Bookmark(member, post);
         bookmarkRepository.save(bookmark);
-
-        notificationService.createBookmarkNotification(postId, userId);
 
         return new BookmarkResponse(
                 post.getPostId(),


### PR DESCRIPTION
## 📌 관련 이슈

- closes #165

## 🛠 작업 내용
- `BookmarkService`에서 북마크 생성 시 호출되던 알림 생성 로직 제거
- 북마크 기능과 무관한 `NotificationService` 의존성 제거
- 북마크 저장/취소 기능은 그대로 유지되도록 정리

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.

- 북마크 생성 시 더 이상 알림이 생성되지 않는지
- 북마크 추가/취소 기능은 기존과 동일하게 정상 동작하는지
- `BookmarkService`에서 불필요한 알림 의존성이 깔끔하게 제거되었는지

## 🐛 버그 현상
- 현재 게시글 북마크 시 게시글 작성자에게 알림이 발송되고 있습니다.
- 북마크 기능은 저장/취소 기능만 수행해야 하지만, 현재 서비스 로직에 알림 생성까지 포함되어 있습니다.
- 이로 인해 사용자에게 불필요한 알림이 전달되고 있으며, 기획 의도와 실제 동작이 일치하지 않습니다.

## 🔁 재현 방법
1. 다른 사용자의 게시글에 로그인한 상태로 접속합니다.
2. 해당 게시글에 북마크를 추가합니다.
3. 게시글 작성자 계정에서 알림 목록을 확인합니다.
4. 북마크 관련 알림이 생성되는지 확인합니다.

## ✅ 기대 결과
- 북마크를 추가해도 알림이 생성되지 않아야 합니다.
- 기존 북마크 추가/취소 기능 자체는 정상적으로 동작해야 합니다.
- 북마크 여부 및 북마크 목록 조회 기능에는 영향이 없어야 합니다.

## ✅ 변경 사항 상세

### 1. 북마크 알림 생성 제거
`BookmarkService`에서 북마크 생성 직후 호출되던 알림 생성 로직을 제거했습니다.

기존:
```java
bookmarkRepository.save(bookmark);
notificationService.createBookmarkNotification(postId, userId);