### PR TITLE
[Refactor] #162 Report targetType 타입 안정화

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/controller/AdminReportController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/controller/AdminReportController.java
@@ -7,10 +7,7 @@ import com.back.devc.domain.interaction.report.entity.ReportStatus;
 import com.back.devc.domain.interaction.report.service.AdminReportService;
 import com.back.devc.global.exception.ApiException;
 import com.back.devc.global.exception.ErrorCode;
-import static com.back.devc.global.security.jwt.JwtPrincipalHelper.getAuthenticatedUserId;
-
-import com.back.devc.global.exception.ApiException;
-import com.back.devc.global.exception.ErrorCode;
+import com.back.devc.global.response.SuccessCode;
 import com.back.devc.global.response.SuccessResponse;
 import com.back.devc.global.security.jwt.JwtPrincipal;
 import lombok.RequiredArgsConstructor;

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/dto/AdminReportRequestDTO.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/dto/AdminReportRequestDTO.java
@@ -1,10 +1,11 @@
 package com.back.devc.domain.interaction.report.dto;
 
 import com.back.devc.domain.interaction.report.entity.SanctionType;
+import com.back.devc.domain.interaction.report.entity.TargetType;
 
 public record AdminReportRequestDTO(
         Long reportId,
-        String targetType,
+        TargetType targetType,
         String adminNote,
         SanctionType sanctionType,
         Integer suspensionDays

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/dto/ReportGroupResponseDTO.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/dto/ReportGroupResponseDTO.java
@@ -1,12 +1,13 @@
 package com.back.devc.domain.interaction.report.dto;
 
 import com.back.devc.domain.interaction.report.entity.ReportStatus;
+import com.back.devc.domain.interaction.report.entity.TargetType;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record ReportGroupResponseDTO(
-        String targetType,
+        TargetType targetType,
         Long targetId,
         String targetNickname,
         String targetTitle,

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/dto/ReportResponseDTO.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/dto/ReportResponseDTO.java
@@ -2,6 +2,7 @@ package com.back.devc.domain.interaction.report.dto;
 
 import com.back.devc.domain.interaction.report.entity.Report;
 import com.back.devc.domain.interaction.report.entity.ReportStatus;
+import com.back.devc.domain.interaction.report.entity.TargetType;
 
 import java.time.LocalDateTime;
 
@@ -12,7 +13,7 @@ public record ReportResponseDTO(
         String reporterEmail,
         String reporterNickname,
 
-        String targetType,
+        TargetType targetType,
         Long targetId,
 
         String targetNickname,

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/entity/Report.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/entity/Report.java
@@ -39,7 +39,7 @@ public class Report {
     private Member reporter;
 
     @Column(name = "target_type", nullable = false, length = 20)
-    private String targetType;
+    private TargetType  targetType;
 
     @Column(name = "target_id", nullable = false)
     private Long targetId;
@@ -67,7 +67,7 @@ public class Report {
 
     @Builder
     public Report(Member reporter,
-                  String targetType,
+                  TargetType  targetType,
                   Long targetId,
                   String reasonType,
                   String reasonDetail) {

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/entity/Report.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/entity/Report.java
@@ -38,7 +38,7 @@ public class Report {
     @JoinColumn(name = "reporter_user_id", nullable = false)
     private Member reporter;
 
-    @Column(name = "target_type", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
     private TargetType  targetType;
 
     @Column(name = "target_id", nullable = false)

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/entity/TargetType.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/entity/TargetType.java
@@ -1,0 +1,6 @@
+package com.back.devc.domain.interaction.report.entity;
+
+public enum TargetType {
+    POST,
+    COMMENT
+}

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/repository/ReportRepository.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/repository/ReportRepository.java
@@ -39,5 +39,5 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     List<Report> findAllByTargetTypeAndTargetId(TargetType targetType, Long targetId);
 
-    boolean existsByReporterAndTargetTypeAndTargetId(Member reporter, String type, Long targetId);
+    boolean existsByReporterAndTargetTypeAndTargetId(Member reporter, TargetType targetType, Long targetId);
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/repository/ReportRepository.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/repository/ReportRepository.java
@@ -2,6 +2,7 @@ package com.back.devc.domain.interaction.report.repository;
 
 import com.back.devc.domain.interaction.report.entity.Report;
 import com.back.devc.domain.interaction.report.entity.ReportStatus;
+import com.back.devc.domain.interaction.report.entity.TargetType;
 import com.back.devc.domain.member.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,9 +35,9 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     )
     Page<Object[]> findGroupedReports(@Param("status") ReportStatus status, Pageable pageable);
 
-    List<Report> findAllByTargetTypeAndTargetIdAndStatus(String targetType, Long targetId, ReportStatus reportStatus);
+    List<Report> findAllByTargetTypeAndTargetIdAndStatus(TargetType targetType, Long targetId, ReportStatus reportStatus);
 
-    List<Report> findAllByTargetTypeAndTargetId(String targetType, Long targetId);
+    List<Report> findAllByTargetTypeAndTargetId(TargetType targetType, Long targetId);
 
     boolean existsByReporterAndTargetTypeAndTargetId(Member reporter, String type, Long targetId);
 }

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/AdminReportService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/AdminReportService.java
@@ -184,11 +184,10 @@ public class AdminReportService {
                                     SanctionType sanctionType, Integer suspensionDays) {
 
         notify(report, admin);
-        TargetType targetType = TargetType.valueOf(report.getTargetType());
         if (approved) {
-            deleteTarget(targetType, report.getTargetId());
+            deleteTarget(report.getTargetType(), report.getTargetId());
             applyTargetMemberSanction(
-                    targetType,
+                    report.getTargetType(),
                     report.getTargetId(),
                     sanctionType,
                     suspensionDays
@@ -271,13 +270,12 @@ public class AdminReportService {
 
     private void notify(Report report, Member admin) {
 
-        TargetType targetType = TargetType.valueOf(report.getTargetType());
 
-        if (targetType == TargetType.POST) {
+        if (report.getTargetType() == TargetType.POST) {
             notificationService.createPostReportNotification(
                     report.getTargetId(), admin.getUserId());
 
-        } else if (targetType == TargetType.COMMENT) {
+        } else if (report.getTargetType() == TargetType.COMMENT) {
             notificationService.createCommentReportNotification(
                     report.getTargetId(), admin.getUserId());
         }
@@ -317,16 +315,15 @@ public class AdminReportService {
         String targetTitle = null;
         String targetContent = null;
 
-        TargetType targetType = TargetType.valueOf(report.getTargetType());
 
-        if (targetType == TargetType.POST) {
+        if (report.getTargetType() == TargetType.POST) {
             Post post = postRepository.findById(report.getTargetId()).orElse(null);
             if (post != null) {
                 targetNickname = post.getMember().getNickname();
                 targetTitle = post.getTitle();
                 targetContent = post.getContent();
             }
-        } else if (targetType == TargetType.COMMENT) {
+        } else if (report.getTargetType() == TargetType.COMMENT) {
             Comment comment = commentRepository.findById(report.getTargetId()).orElse(null);
             if (comment != null) {
                 targetNickname = memberRepository.findById(comment.getUserId())

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/AdminReportService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/AdminReportService.java
@@ -4,9 +4,7 @@ import com.back.devc.domain.interaction.notification.service.NotificationService
 import com.back.devc.domain.interaction.report.dto.AdminReportRequestDTO;
 import com.back.devc.domain.interaction.report.dto.ReportGroupResponseDTO;
 import com.back.devc.domain.interaction.report.dto.ReportResponseDTO;
-import com.back.devc.domain.interaction.report.entity.Report;
-import com.back.devc.domain.interaction.report.entity.ReportStatus;
-import com.back.devc.domain.interaction.report.entity.SanctionType;
+import com.back.devc.domain.interaction.report.entity.*;
 import com.back.devc.domain.interaction.report.repository.ReportRepository;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.entity.MemberStatus;
@@ -38,7 +36,9 @@ public class AdminReportService {
     private final CommentRepository commentRepository;
     private final NotificationService notificationService;
 
-    // 1. 단건 신고 조회
+    /* =========================================================
+     * 1. 단건 신고 조회
+     * ========================================================= */
     @Transactional(readOnly = true)
     public Page<ReportResponseDTO> getReports(ReportStatus status, Pageable pageable) {
         Page<Report> reports = (status == null)
@@ -48,7 +48,9 @@ public class AdminReportService {
         return reports.map(this::toDtoWithTargetInfo);
     }
 
-    // 2. 단건 승인 처리
+    /* =========================================================
+     * 2. 단건 승인
+     * ========================================================= */
     public void approveReport(Long adminId, AdminReportRequestDTO dto) {
         Report report = findReportOrThrow(dto.reportId());
         Member admin = findMemberOrThrow(adminId);
@@ -59,7 +61,9 @@ public class AdminReportService {
         handleTargetAction(report, admin, true, dto.sanctionType(), dto.suspensionDays());
     }
 
-    // 3. 단건 반려
+    /* =========================================================
+     * 3. 단건 반려
+     * ========================================================= */
     public void rejectReport(Long adminId, AdminReportRequestDTO dto) {
         Report report = findReportOrThrow(dto.reportId());
         Member admin = findMemberOrThrow(adminId);
@@ -70,13 +74,16 @@ public class AdminReportService {
         handleTargetAction(report, admin, false, null, null);
     }
 
-    // 4. 그룹(게시글/댓글 사용자별) 조회
+    /* =========================================================
+     * 4. 그룹 조회
+     * ========================================================= */
     @Transactional(readOnly = true)
     public Page<ReportGroupResponseDTO> getGroupedReports(ReportStatus status, Pageable pageable) {
         Page<Object[]> result = reportRepository.findGroupedReports(status, pageable);
 
         return result.map(row -> {
-            String targetType = (String) row[0];
+
+            TargetType targetType = (TargetType) row[0];
             Long targetId = (Long) row[1];
             Long reportCount = (Long) row[2];
             LocalDateTime latestCreatedAt = (LocalDateTime) row[3];
@@ -86,20 +93,21 @@ public class AdminReportService {
             String targetContent = null;
 
             List<String> reasonTypes = new ArrayList<>();
-            List<Report> reports = reportRepository.findAllByTargetTypeAndTargetId(targetType, targetId);
+            List<Report> reports =
+                    reportRepository.findAllByTargetTypeAndTargetId(targetType, targetId);
 
             for (Report r : reports) {
                 reasonTypes.add(r.getReasonType());
             }
 
-            if ("POST".equals(targetType)) {
+            if (targetType == TargetType.POST) {
                 Post post = postRepository.findById(targetId).orElse(null);
                 if (post != null) {
                     targetNickname = post.getMember().getNickname();
                     targetTitle = post.getTitle();
                     targetContent = post.getContent();
                 }
-            } else if ("COMMENT".equals(targetType)) {
+            } else if (targetType == TargetType.COMMENT) {
                 Comment comment = commentRepository.findById(targetId).orElse(null);
                 if (comment != null) {
                     targetContent = comment.getContent();
@@ -109,22 +117,31 @@ public class AdminReportService {
             }
 
             return new ReportGroupResponseDTO(
-                    targetType, targetId, targetNickname, targetTitle, targetContent,
-                    reportCount, reasonTypes, ReportStatus.PENDING, latestCreatedAt
+                    targetType,
+                    targetId,
+                    targetNickname,
+                    targetTitle,
+                    targetContent,
+                    reportCount,
+                    reasonTypes,
+                    ReportStatus.PENDING,
+                    latestCreatedAt
             );
         });
     }
 
-    // 5. 그룹 승인 처리
+    /* =========================================================
+     * 5. 그룹 승인
+     * ========================================================= */
     public void approveReportGroup(Long adminId, AdminReportRequestDTO dto) {
         Member admin = findMemberOrThrow(adminId);
 
-        // targetType, targetId는 DTO에서 가져옴 (reportId가 그룹 대표 targetId로 사용됨)
-        String targetType = dto.targetType();
-        Long targetId = dto.reportId(); // 프론트에서 targetId를 reportId로 전달
+        TargetType targetType = dto.targetType();
+        Long targetId = dto.reportId();
 
-        List<Report> reports = reportRepository.findAllByTargetTypeAndTargetIdAndStatus(
-                targetType, targetId, ReportStatus.PENDING);
+        List<Report> reports =
+                reportRepository.findAllByTargetTypeAndTargetIdAndStatus(
+                        targetType, targetId, ReportStatus.PENDING);
 
         if (reports.isEmpty()) return;
 
@@ -132,18 +149,22 @@ public class AdminReportService {
             report.processReport(admin);
         }
 
-        handleGroupTargetAction(targetType, targetId, admin, true, dto.sanctionType(), dto.suspensionDays());
+        handleGroupTargetAction(targetType, targetId, admin, true,
+                dto.sanctionType(), dto.suspensionDays());
     }
 
-    // 6. 그룹 반려 처리
+    /* =========================================================
+     * 6. 그룹 반려
+     * ========================================================= */
     public void rejectReportGroup(Long adminId, AdminReportRequestDTO dto) {
         Member admin = findMemberOrThrow(adminId);
 
-        String targetType = dto.targetType();
+        TargetType targetType = dto.targetType();
         Long targetId = dto.reportId();
 
-        List<Report> reports = reportRepository.findAllByTargetTypeAndTargetIdAndStatus(
-                targetType, targetId, ReportStatus.PENDING);
+        List<Report> reports =
+                reportRepository.findAllByTargetTypeAndTargetIdAndStatus(
+                        targetType, targetId, ReportStatus.PENDING);
 
         if (reports.isEmpty()) return;
 
@@ -151,79 +172,83 @@ public class AdminReportService {
             report.rejectReport(admin);
         }
 
-        handleGroupTargetAction(targetType, targetId, admin, false, null, null);
+        handleGroupTargetAction(targetType, targetId, admin,
+                false, null, null);
     }
 
     /* =========================================================
-     * 공통 처리 로직
+     * 공통 처리
      * ========================================================= */
 
     private void handleTargetAction(Report report, Member admin, boolean approved,
                                     SanctionType sanctionType, Integer suspensionDays) {
+
         notify(report, admin);
+        TargetType targetType = TargetType.valueOf(report.getTargetType());
         if (approved) {
-            deleteTarget(report.getTargetType(), report.getTargetId());
-            applyTargetMemberSanction(report.getTargetType(), report.getTargetId(), sanctionType, suspensionDays);
+            deleteTarget(targetType, report.getTargetId());
+            applyTargetMemberSanction(
+                    targetType,
+                    report.getTargetId(),
+                    sanctionType,
+                    suspensionDays
+            );
         }
     }
 
-    private void handleGroupTargetAction(String targetType, Long targetId, Member admin,
+    private void handleGroupTargetAction(TargetType targetType, Long targetId, Member admin,
                                          boolean approved, SanctionType sanctionType, Integer suspensionDays) {
+
         notifyGroup(targetType, targetId, admin);
+
         if (approved) {
             deleteTarget(targetType, targetId);
             applyTargetMemberSanction(targetType, targetId, sanctionType, suspensionDays);
         }
     }
 
-    /**
-     * 대상 게시글/댓글을 삭제(soft delete) 처리한다.
-     */
-    private void deleteTarget(String targetType, Long targetId) {
-        if ("POST".equals(targetType)) {
+    /* =========================================================
+     * Target 처리
+     * ========================================================= */
+
+    private void deleteTarget(TargetType targetType, Long targetId) {
+        if (targetType == TargetType.POST) {
             postRepository.findById(targetId).ifPresent(post -> {
                 if (!post.isDeleted()) post.delete();
             });
-        } else if ("COMMENT".equals(targetType)) {
+        } else if (targetType == TargetType.COMMENT) {
             commentRepository.findById(targetId).ifPresent(comment -> {
                 if (!comment.isDeleted()) comment.softDelete();
             });
         }
     }
 
-    /**
-     * 대상 게시글/댓글의 작성자를 찾아 관리자가 선택한 제재를 직접 적용한다.
-     * 자동 escalate 방식을 제거하고 관리자가 명시적으로 선택한 SanctionType을 따른다.
-     */
-    private void applyTargetMemberSanction(String targetType, Long targetId,
+    private void applyTargetMemberSanction(TargetType targetType, Long targetId,
                                            SanctionType sanctionType, Integer suspensionDays) {
+
         if (sanctionType == null) return;
 
         Member member = null;
 
-        if ("POST".equals(targetType)) {
+        if (targetType == TargetType.POST) {
             Post post = postRepository.findById(targetId).orElse(null);
             if (post != null) member = post.getMember();
-        } else if ("COMMENT".equals(targetType)) {
+
+        } else if (targetType == TargetType.COMMENT) {
             Comment comment = commentRepository.findById(targetId).orElse(null);
-            if (comment != null) member = memberRepository.findById(comment.getUserId()).orElse(null);
+            if (comment != null) {
+                member = memberRepository.findById(comment.getUserId()).orElse(null);
+            }
         }
 
         if (member == null) return;
+
         applySanction(member, sanctionType, suspensionDays);
     }
 
-    /**
-     * 관리자가 선택한 제재 유형에 따라 회원 상태를 직접 설정한다.
-     *
-     * - WARNED      : 경고 상태로 변경 (이미 상위 제재 상태면 변경하지 않음)
-     * - SUSPENDED   : suspensionDays 기간만큼 정지, suspendedUntil 설정
-     * - BLACKLISTED : 영구 차단
-     */
     private void applySanction(Member member, SanctionType sanctionType, Integer suspensionDays) {
         switch (sanctionType) {
             case WARNED -> {
-                // 이미 정지/차단 상태라면 경고로 되돌리지 않는다 (하향 방지)
                 if (member.getStatus() == MemberStatus.ACTIVE) {
                     member.updateStatus(MemberStatus.WARNED);
                 }
@@ -235,30 +260,40 @@ public class AdminReportService {
             }
             case BLACKLISTED -> {
                 member.updateStatus(MemberStatus.BLACKLISTED);
-                member.setSuspendedUntil(null); // 영구 차단은 기간 불필요
+                member.setSuspendedUntil(null);
             }
         }
     }
 
     /* =========================================================
-     * 알림 및 편의 메서드
+     * Notification
      * ========================================================= */
 
     private void notify(Report report, Member admin) {
-        if ("POST".equals(report.getTargetType())) {
-            notificationService.createPostReportNotification(report.getTargetId(), admin.getUserId());
-        } else if ("COMMENT".equals(report.getTargetType())) {
-            notificationService.createCommentReportNotification(report.getTargetId(), admin.getUserId());
+
+        TargetType targetType = TargetType.valueOf(report.getTargetType());
+
+        if (targetType == TargetType.POST) {
+            notificationService.createPostReportNotification(
+                    report.getTargetId(), admin.getUserId());
+
+        } else if (targetType == TargetType.COMMENT) {
+            notificationService.createCommentReportNotification(
+                    report.getTargetId(), admin.getUserId());
         }
     }
 
-    private void notifyGroup(String targetType, Long targetId, Member admin) {
-        if ("POST".equals(targetType)) {
+    private void notifyGroup(TargetType targetType, Long targetId, Member admin) {
+        if (targetType == TargetType.POST) {
             notificationService.createPostReportNotification(targetId, admin.getUserId());
-        } else if ("COMMENT".equals(targetType)) {
+        } else if (targetType == TargetType.COMMENT) {
             notificationService.createCommentReportNotification(targetId, admin.getUserId());
         }
     }
+
+    /* =========================================================
+     * Util
+     * ========================================================= */
 
     private void validatePendingStatus(Report report) {
         if (report.getStatus() != ReportStatus.PENDING) {
@@ -277,22 +312,26 @@ public class AdminReportService {
     }
 
     private ReportResponseDTO toDtoWithTargetInfo(Report report) {
+
         String targetNickname = null;
         String targetTitle = null;
         String targetContent = null;
 
-        if ("POST".equals(report.getTargetType())) {
+        TargetType targetType = TargetType.valueOf(report.getTargetType());
+
+        if (targetType == TargetType.POST) {
             Post post = postRepository.findById(report.getTargetId()).orElse(null);
             if (post != null) {
                 targetNickname = post.getMember().getNickname();
                 targetTitle = post.getTitle();
                 targetContent = post.getContent();
             }
-        } else if ("COMMENT".equals(report.getTargetType())) {
+        } else if (targetType == TargetType.COMMENT) {
             Comment comment = commentRepository.findById(report.getTargetId()).orElse(null);
             if (comment != null) {
                 targetNickname = memberRepository.findById(comment.getUserId())
-                        .map(Member::getNickname).orElse(null);
+                        .map(Member::getNickname)
+                        .orElse(null);
                 targetContent = comment.getContent();
             }
         }

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/UserReportService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/UserReportService.java
@@ -3,6 +3,7 @@ package com.back.devc.domain.interaction.report.service;
 import com.back.devc.domain.interaction.notification.service.NotificationService;
 import com.back.devc.domain.interaction.report.dto.ReportRequestDTO;
 import com.back.devc.domain.interaction.report.entity.Report;
+import com.back.devc.domain.interaction.report.entity.TargetType;
 import com.back.devc.domain.interaction.report.repository.ReportRepository;
 import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
@@ -25,80 +26,86 @@ public class UserReportService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
-    // 신고 저장 성공 후 대상 작성자에게 신고 알림을 생성하기 위해 사용하는 서비스
     private final NotificationService notificationService;
 
+    /* =========================================================
+     * POST 신고
+     * ========================================================= */
     public void reportPost(Long reporterId, ReportRequestDTO dto) {
+
         Member reporter = findMemberOrThrow(reporterId);
-        Post post = postRepository.findById(dto.getTargetId())
+
+        Post post = postRepository.findById(dto.targetId())
                 .orElseThrow(() -> new ApiException(ErrorCode.POST_NOT_FOUND));
 
-        // 1. 본인 신고 방지
-        if (post.getMember().getUserId().equals(reporterId)) {
-            throw new ApiException(ErrorCode.CANNOT_REPORT_SELF);
-        }
-
-        // 2. 삭제 상태 체크
-        if (post.isDeleted()) {
-            throw new ApiException(ErrorCode.ALREADY_DELETED);
-        }
-
-        // 3. 중복 신고 체크
-        validateDuplicateReport(reporter, "POST", dto.getTargetId());
+        validateSelfReport(post.getMember().getUserId(), reporterId);
+        validateDeleted(post.isDeleted());
+        validateDuplicateReport(reporter, TargetType.POST, dto.targetId());
 
         Report report = Report.builder()
                 .reporter(reporter)
-                .targetType("POST")
-                .targetId(dto.getTargetId())
-                .reasonType(dto.getReasonType())
-                .reasonDetail(dto.getReasonDetail())
+                .targetType(TargetType.POST)
+                .targetId(dto.targetId())
+                .reasonType(dto.reasonType())
+                .reasonDetail(dto.reasonDetail())
                 .build();
 
         reportRepository.save(report);
-        // 신고 저장이 끝난 뒤 신고된 게시글의 작성자에게 REPORT 알림을 생성
-        // 실제 알림 생성 가능 여부(자기 자신 신고인지, 중복 알림인지 등)는 NotificationService 에서 한 번 더 검증
-        notificationService.createPostReportNotification(dto.getTargetId(), reporterId);
+
+        notificationService.createPostReportNotification(dto.targetId(), reporterId);
     }
 
+    /* =========================================================
+     * COMMENT 신고
+     * ========================================================= */
     public void reportComment(Long reporterId, ReportRequestDTO dto) {
+
         Member reporter = findMemberOrThrow(reporterId);
-        Comment comment = commentRepository.findById(dto.getTargetId())
+
+        Comment comment = commentRepository.findById(dto.targetId())
                 .orElseThrow(() -> new ApiException(ErrorCode.COMMENT_NOT_FOUND));
 
-        // 1. 본인 신고 방지
-        if (comment.getUserId().equals(reporterId)) {
-            throw new ApiException(ErrorCode.CANNOT_REPORT_SELF);
-        }
-
-        // 2. 삭제 상태 체크
-        if (comment.isDeleted()) {
-            throw new ApiException(ErrorCode.ALREADY_DELETED);
-        }
-
-        // 3. 중복 신고 체크
-        validateDuplicateReport(reporter, "COMMENT", dto.getTargetId());
+        validateSelfReport(comment.getUserId(), reporterId);
+        validateDeleted(comment.isDeleted());
+        validateDuplicateReport(reporter, TargetType.COMMENT, dto.targetId());
 
         Report report = Report.builder()
                 .reporter(reporter)
-                .targetType("COMMENT")
-                .targetId(dto.getTargetId())
-                .reasonType(dto.getReasonType())
-                .reasonDetail(dto.getReasonDetail())
+                .targetType(TargetType.COMMENT)
+                .targetId(dto.targetId())
+                .reasonType(dto.reasonType())
+                .reasonDetail(dto.reasonDetail())
                 .build();
 
         reportRepository.save(report);
-        // 신고 저장이 끝난 뒤 신고된 댓글의 작성자에게 REPORT 알림을 생성
-        // 실제 알림 생성 가능 여부(자기 자신 신고인지, 중복 알림인지 등)는 NotificationService 에서 한 번 더 검증
-        notificationService.createCommentReportNotification(dto.getTargetId(), reporterId);
+
+        notificationService.createCommentReportNotification(dto.targetId(), reporterId);
     }
+
+    /* =========================================================
+     * Validation
+     * ========================================================= */
 
     private Member findMemberOrThrow(Long userId) {
         return memberRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
-    private void validateDuplicateReport(Member reporter, String type, Long targetId) {
-        if (reportRepository.existsByReporterAndTargetTypeAndTargetId(reporter, type, targetId)) {
+    private void validateSelfReport(Long targetUserId, Long reporterId) {
+        if (targetUserId.equals(reporterId)) {
+            throw new ApiException(ErrorCode.CANNOT_REPORT_SELF);
+        }
+    }
+
+    private void validateDeleted(boolean deleted) {
+        if (deleted) {
+            throw new ApiException(ErrorCode.ALREADY_DELETED);
+        }
+    }
+
+    private void validateDuplicateReport(Member reporter, TargetType type, Long targetId) {
+        if (reportRepository.existsByReporterAndTargetTypeAndTargetId(
+                reporter, type, targetId)) {
             throw new ApiException(ErrorCode.REPORT_ALREADY_EXISTS);
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #162 

## 🛠️ 작업 내용
- Report 도메인 targetType String → TargetType enum 전환
- UserReportService / AdminReportService 전반 enum 기반 구조로 변경
- 신고 중복 검증 및 생성 로직에서 String 제거

## 🎯 리뷰 포인트
- Report Entity의 TargetType이 String → Enum으로 전환되면서 발생할 수 있는 호환성 문제 여부