### PR TITLE
158 feat 프론트 인기글 메인 기존 카테고리 번호에서 카테고리명으로 구현

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/dto/BookmarkedPostResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/dto/BookmarkedPostResponse.java
@@ -6,6 +6,7 @@ public record BookmarkedPostResponse(
         long postId,
         String title,
         String authorNickname,
+        long categoryId,
         long likeCount,
         long commentCount,
         LocalDateTime createdAt

--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/service/BookmarkService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/bookmark/service/BookmarkService.java
@@ -96,6 +96,7 @@ public class BookmarkService {
                             post.getPostId(),
                             post.getTitle(),
                             MemberDisplayUtil.getDisplayName(post.getMember()),
+                            post.getCategory().getCategoryId(),
                             post.getLikeCount(),
                             post.getCommentCount(),
                             post.getCreatedAt()

--- a/frontend/app/category/[slug]/page.tsx
+++ b/frontend/app/category/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import { PostCard, type Post } from "@/components/post-card"
 import Link from "next/link"
 import { useParams } from "next/navigation"
+import { categoryLabelMap, categorySlugMap } from "@/constants/category"
 
 type PostPageResponse = {
   content: {
@@ -21,22 +22,6 @@ type PostPageResponse = {
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
-
-// slug → categoryId 매핑
-const categoryMap: Record<string, number> = {
-  tech: 1,
-  "job-market": 2,
-  trend: 3,
-  free: 4,
-}
-
-// 기존 유지
-const allCategories = [
-  { slug: "tech", name: "IT 기술 정보" },
-  { slug: "job-market", name: "취업 시장 정보" },
-  { slug: "trend", name: "개발자 트렌드" },
-  { slug: "free", name: "자유 주제" },
-]
 
 const formatTimeAgo = (dateString: string) => {
   const date = new Date(dateString)
@@ -60,14 +45,27 @@ export default function CategoryPage() {
   const [posts, setPosts] = useState<Post[]>([])
   const [loading, setLoading] = useState(true)
 
-  const categoryName =
-    allCategories.find((c) => c.slug === slug)?.name || slug
+  // slug → categoryId 자동 변환
+  const categoryMap: Record<string, number> = Object.fromEntries(
+    Object.entries(categorySlugMap).map(([id, slug]) => [slug, Number(id)])
+  )
+
+  const categoryId = categoryMap[slug]
+
+  //category 이름도 constants 기반
+  const categoryName = categoryLabelMap[categoryId] ?? slug
+
+  //navigation도 자동 생성
+  const allCategories = Object.entries(categorySlugMap).map(
+    ([id, slug]) => ({
+      slug,
+      name: categoryLabelMap[Number(id)],
+    })
+  )
 
   useEffect(() => {
     const fetchPosts = async () => {
       try {
-        const categoryId = categoryMap[slug]
-
         if (!categoryId) return
 
         const response = await fetch(
@@ -85,7 +83,9 @@ export default function CategoryPage() {
           title: post.title,
           excerpt: post.content,
           author: { name: post.nickName },
-          category: categoryName,
+          category: categoryLabelMap[post.categoryId],
+          categorySlug: categorySlugMap[post.categoryId], 
+          categoryId : post.categoryId,
           createdAt: formatTimeAgo(post.createdAt),
           likes: post.likeCount,
           comments: post.commentCount,
@@ -102,7 +102,7 @@ export default function CategoryPage() {
     }
 
     fetchPosts()
-  }, [slug])
+  }, [slug, categoryId])
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">

--- a/frontend/app/feed/page.tsx
+++ b/frontend/app/feed/page.tsx
@@ -9,11 +9,13 @@ import { Input } from "@/components/ui/input"
 import { apiFetch } from "@/lib/api"
 import { getAuthSnapshot } from "@/lib/auth-storage"
 import Link from "next/link"
+import { categoryLabelMap, categorySlugMap } from "@/constants/category"
 
 type BookmarkedPostResponse = {
   postId: number
   title: string
   authorNickname: string
+  categoryId : number
   likeCount: number
   commentCount: number
   createdAt: string
@@ -53,7 +55,9 @@ function mapBookmarkedPostsToPostCard(
     title: post.title,
     excerpt: "",
     author: { name: post.authorNickname },
-    category: "북마크",
+    category: categoryLabelMap[post.categoryId],
+    categorySlug: categorySlugMap[post.categoryId],
+    categoryId: post.categoryId,
     createdAt: formatRelativeDate(post.createdAt),
     likes: post.likeCount,
     comments: post.commentCount,

--- a/frontend/app/latest/page.tsx
+++ b/frontend/app/latest/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react"
 import { PostCard, type Post } from "@/components/post-card"
 import { Clock } from "lucide-react"
 import { getAccessToken } from "@/lib/auth-storage"
+import { categoryLabelMap, categorySlugMap } from "@/constants/category"
+
 
 type PostPageResponse = {
   content: {
@@ -24,13 +26,6 @@ type PostPageResponse = {
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
-
-const categoryLabelMap: Record<number, string> = {
-  1: "IT 기술 정보",
-  2: "취업 시장 정보",
-  3: "개발자 트렌드",
-  4: "자유 주제",
-}
 
 const formatTimeAgo = (dateString: string) => {
   const date = new Date(dateString)
@@ -87,7 +82,9 @@ export default function LatestPage() {
             name: post.nickName,
             userId: post.userId,
           },
-          category: categoryLabelMap[post.categoryId] ?? String(post.categoryId),
+          category: categoryLabelMap[post.categoryId],
+          categorySlug: categorySlugMap[post.categoryId],
+          categoryId: post.categoryId,
           createdAt: formatTimeAgo(post.createdAt),
           likes: post.likeCount,
           comments: post.commentCount,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from "react"
 import { PostCard, type Post } from "@/components/post-card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { TrendingUp, Clock, Users } from "lucide-react"
+import { categoryLabelMap, categorySlugMap } from "@/constants/category"
+
 import {
   AUTH_CHANGED_EVENT,
   getAccessToken,
@@ -35,6 +37,7 @@ type BookmarkedPostResponse = {
   postId: number
   title: string
   authorNickname: string
+  categoryId : number
   likeCount: number
   commentCount: number
   createdAt: string
@@ -107,7 +110,9 @@ function mapBookmarkedPostsToPostCard(
     title: post.title,
     excerpt: "",
     author: { name: post.authorNickname },
-    category: "북마크",
+    category: categoryLabelMap[post.categoryId],
+    categorySlug: categorySlugMap[post.categoryId],
+    categoryId: post.categoryId,
     createdAt: formatRelativeDate(post.createdAt),
     likes: post.likeCount,
     comments: post.commentCount,
@@ -158,7 +163,9 @@ export default function HomePage() {
           author: {
             name: post.nickName,
           },
-          category: String(post.categoryId),
+          category: categoryLabelMap[post.categoryId],
+          categorySlug: categorySlugMap[post.categoryId],
+          categoryId: post.categoryId,
           createdAt: formatTimeAgo(post.createdAt),
           likes: post.likeCount,
           comments: post.commentCount,

--- a/frontend/app/popular/page.tsx
+++ b/frontend/app/popular/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { PostCard, type Post } from "@/components/post-card"
 import { TrendingUp } from "lucide-react"
+import { categoryLabelMap, categorySlugMap } from "@/constants/category"
 
 type PostPageResponse = {
   content: {
@@ -23,6 +24,7 @@ type PostPageResponse = {
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
+
 
 const formatTimeAgo = (dateString: string) => {
   const date = new Date(dateString)
@@ -64,7 +66,9 @@ export default function PopularPage() {
             name: post.nickName,
             userId: post.userId,
           },
-          category: String(post.categoryId),
+          category: categoryLabelMap[post.categoryId],
+          categorySlug: categorySlugMap[post.categoryId],
+          categoryId: post.categoryId,
           createdAt: formatTimeAgo(post.createdAt),
           likes: post.likeCount,
           comments: post.commentCount,

--- a/frontend/components/post-card.tsx
+++ b/frontend/components/post-card.tsx
@@ -13,6 +13,8 @@ export interface Post {
     userId?: number
   }
   category: string
+  categorySlug: string
+  categoryId: number
   createdAt: string
   likes: number
   comments: number
@@ -54,7 +56,7 @@ export function PostCard({ post, onBookmarkToggle }: PostCardProps) {
         <div className="min-w-0 flex-1">
           <div className="mb-2 flex items-center gap-2">
             <Link
-              href={`/category/${post.category.toLowerCase()}`}
+              href={`/category/${post.categorySlug}`}
               className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
             >
               {post.category}

--- a/frontend/constants/category.ts
+++ b/frontend/constants/category.ts
@@ -1,0 +1,13 @@
+export const categoryLabelMap: Record<number, string> = {
+    1: "IT 기술 정보",
+    2: "취업 시장 정보",
+    3: "개발자 트렌드",
+    4: "자유 주제",
+  }
+  
+  export const categorySlugMap: Record<number, string> = {
+    1: "tech",
+    2: "job-market",
+    3: "trend",
+    4: "free",
+  }


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.

- [x] 프론트 카테고리 매핑하는 코드 -> 중복되기 때문에 constants/category.ts 로 따로 폴더를 빼서 만들었습니다.

- [x] 인기글, 메인에서 보였던 (카테고리 넘버) - > 카테고리 명으로 구현했습니다.

- [x] 북마크쪽에서 카테고리명 대신 -> (북마크)라고만 나왔던 부분을 수정하기 위해
       백엔드 북마크 부분(BookmarkService, BookmarkedPostResponse) 에 카테고리id 를 추가

- [x] 프론트 북마크도 카테고리명이 나오도록 수정하였습니다.

- [x] 모든 (인기글,최신글,북마크) 리스트업 부분에서 -> 게시글의 카테고리를 클릭하면 해당 카테고리별 목록으로 연동되도록 수정하였습니다.

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?