### PR TITLE
fix: 신고 접수 시 즉시 알림 발송 제거(#172)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/UserReportService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/report/service/UserReportService.java
@@ -1,6 +1,5 @@
 package com.back.devc.domain.interaction.report.service;
 
-import com.back.devc.domain.interaction.notification.service.NotificationService;
 import com.back.devc.domain.interaction.report.dto.ReportRequestDTO;
 import com.back.devc.domain.interaction.report.entity.Report;
 import com.back.devc.domain.interaction.report.entity.TargetType;
@@ -26,7 +25,6 @@ public class UserReportService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
-    private final NotificationService notificationService;
 
     /* =========================================================
      * POST 신고
@@ -52,7 +50,6 @@ public class UserReportService {
 
         reportRepository.save(report);
 
-        notificationService.createPostReportNotification(dto.targetId(), reporterId);
     }
 
     /* =========================================================
@@ -79,7 +76,6 @@ public class UserReportService {
 
         reportRepository.save(report);
 
-        notificationService.createCommentReportNotification(dto.targetId(), reporterId);
     }
 
     /* =========================================================


### PR DESCRIPTION
## 📌 관련 이슈

Closes #172 

## 🛠️ 작업 내용
- `UserReportService`에서 신고 접수 직후 호출되던 신고 알림 생성 로직 제거

- 신고 접수 단계에서는 신고 데이터만 저장되도록 정리

- 신고 알림은 관리자 처리 완료 시점에만 발송되도록 흐름 분리

## 🎯 리뷰 포인트
- 신고 접수 시점에 더 이상 알림이 생성되지 않는지

- 게시글 신고 / 댓글 신고 저장 기능은 기존과 동일하게 동작하는지

- 관리자 처리 후 알림 발송 흐름과 충돌이 없는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?