### PR TITLE
Feat : 프론트 모든 게시글 작성자 닉네임 앞에 "작성자" 로 표시되도록 코드 구현

### DIFF
--- a/frontend/components/post-card.tsx
+++ b/frontend/components/post-card.tsx
@@ -79,22 +79,22 @@ export function PostCard({ post, onBookmarkToggle }: PostCardProps) {
           <div className="flex items-center justify-between">
             {authorProfileHref ? (
               <Link href={authorProfileHref} className="flex items-center gap-2">
-                <Avatar className="h-6 w-6">
-                  <AvatarImage src={post.author.avatar} alt={post.author.name} />
-                  <AvatarFallback className="bg-secondary text-xs text-secondary-foreground">
-                    {post.author.name.slice(0, 2).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
+             <Avatar className="h-10 w-10">
+                <AvatarImage src={post.author.avatar} alt={post.author.name} />
+                <AvatarFallback className="bg-secondary text-xs text-secondary-foreground">
+                  작성자
+                </AvatarFallback>
+              </Avatar>
                 <span className="text-sm text-muted-foreground transition-colors hover:text-foreground">
                   {post.author.name}
                 </span>
               </Link>
             ) : (
               <div className="flex items-center gap-2">
-                <Avatar className="h-6 w-6">
+                <Avatar className="h-10 w-10">
                   <AvatarImage src={post.author.avatar} alt={post.author.name} />
                   <AvatarFallback className="bg-secondary text-xs text-secondary-foreground">
-                    {post.author.name.slice(0, 2).toUpperCase()}
+                    작성자
                   </AvatarFallback>
                 </Avatar>
                 <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.

- [x] 해당 코드가 들어있는 post-card.tsx 에서 기존 닉네임의 앞 2글자를 슬라이스 하는 방식에서
단순하게 작성자로 표시되도록 수정하였습니다. 3글자를 모두 보이게 하기 위하여 아바타의 크기를 키웠습니다.

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?