### PR TITLE
fix: 비로그인 상태 상호작용 로그인 유도 팝업 처리(#176)

### DIFF
--- a/frontend/app/posts/[postId]/page.tsx
+++ b/frontend/app/posts/[postId]/page.tsx
@@ -1,6 +1,6 @@
 ﻿"use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useParams } from "next/navigation"
 import CommentSection from "@/components/comment/CommentSection"
@@ -22,6 +22,11 @@ type PostDetailResponse = {
   createdAt: string
   updatedAt: string
   liked?: boolean
+}
+
+type LoginRequiredPopupState = {
+  open: boolean
+  message: string
 }
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"
@@ -134,6 +139,27 @@ function getAuthHeaders(): HeadersInit {
   return headers
 }
 
+function isUnauthorizedStatus(status: number): boolean {
+  return status === 401 || status === 403
+}
+
+function isLoginRequiredMessage(message: string | null | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  return message.includes("인증") || message.includes("로그인")
+}
+
+async function extractErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
+  try {
+    const errorData = await response.json()
+    return errorData?.message ?? errorData?.resultMessage ?? errorData?.msg ?? fallbackMessage
+  } catch {
+    return fallbackMessage
+  }
+}
+
 export default function PostDetailPage() {
   const params = useParams()
 
@@ -142,6 +168,10 @@ export default function PostDetailPage() {
   const [error, setError] = useState<string | null>(null)
   const [reportLoading, setReportLoading] = useState(false)
   const [currentUserId, setCurrentUserId] = useState<number | null>(null)
+  const [loginRequiredPopup, setLoginRequiredPopup] = useState<LoginRequiredPopupState>({
+    open: false,
+    message: "로그인이 필요한 기능입니다.",
+  })
 
   const postId = useMemo(() => {
     const rawPostId = params?.postId
@@ -153,6 +183,28 @@ export default function PostDetailPage() {
     () => sanitizeRichTextHtml(post?.content ?? ""),
     [post?.content]
   )
+
+  const loginPath = useMemo(() => "/login", [])
+
+  const openLoginRequiredPopup = useCallback((message = "로그인이 필요한 기능입니다.") => {
+    setLoginRequiredPopup({
+      open: true,
+      message,
+    })
+  }, [])
+
+  const closeLoginRequiredPopup = useCallback(() => {
+    setLoginRequiredPopup((prev) => ({
+      ...prev,
+      open: false,
+    }))
+  }, [])
+
+  const moveToLoginPage = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.location.href = loginPath
+    }
+  }, [loginPath])
 
   useEffect(() => {
     const loadPost = async () => {
@@ -226,23 +278,17 @@ export default function PostDetailPage() {
           reasonDetail: "게시글 상세 페이지에서 접수한 신고입니다.",
         }),
       })
-
       if (!response.ok) {
-        let message = "게시글 신고에 실패했습니다."
+        let message = await extractErrorMessage(response, "게시글 신고에 실패했습니다.")
 
-        try {
-          const errorData = await response.json()
-          message =
-            errorData?.message ??
-            errorData?.resultMessage ??
-            errorData?.msg ??
-            message
+        if (isUnauthorizedStatus(response.status) || isLoginRequiredMessage(message)) {
+          setError(null)
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
 
-          if (typeof message === "string" && message.includes("이미 신고")) {
-            message = "이미 신고한 게시글입니다."
-          }
-        } catch {
-          // keep default message
+        if (typeof message === "string" && message.includes("이미 신고")) {
+          message = "이미 신고한 게시글입니다."
         }
 
         throw new Error(message)
@@ -251,7 +297,15 @@ export default function PostDetailPage() {
       alert("게시글 신고가 접수되었습니다.")
       window.dispatchEvent(new CustomEvent("notifications-updated"))
     } catch (err) {
-      setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
+      const message = err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다."
+
+      if (isLoginRequiredMessage(message)) {
+        setError(null)
+        openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+        return
+      }
+
+      setError(message)
     } finally {
       setReportLoading(false)
     }
@@ -295,7 +349,32 @@ export default function PostDetailPage() {
         ) : error ? (
           <div className="text-destructive">{error}</div>
         ) : (
-          <div>
+          <>
+            {loginRequiredPopup.open && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+                <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-lg">
+                  <h3 className="text-lg font-semibold text-foreground">로그인 안내</h3>
+                  <p className="mt-3 text-sm text-muted-foreground">{loginRequiredPopup.message}</p>
+                  <div className="mt-6 flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={closeLoginRequiredPopup}
+                      className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground"
+                    >
+                      취소
+                    </button>
+                    <button
+                      type="button"
+                      onClick={moveToLoginPage}
+                      className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+                    >
+                      로그인 하러가기
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+            <div>
             <h1 className="text-2xl font-bold text-foreground">{post?.title}</h1>
             {post?.userId ? (
               <div className="mt-2 text-sm text-muted-foreground">
@@ -350,7 +429,8 @@ export default function PostDetailPage() {
             >
               {reportLoading ? "신고 중..." : "신고"}
             </button>
-          </div>
+            </div>
+          </>
         )}
       </section>
 

--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -1,10 +1,15 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { getAccessToken } from "@/lib/auth-storage"
 
 type CommentSectionProps = {
   postId: number
+}
+
+type LoginRequiredPopupState = {
+  open: boolean
+  message: string
 }
 
 type SuccessResponse<T> = {
@@ -122,6 +127,27 @@ function extractCreatedCommentId(responseBody: unknown): number | null {
   const validId = possibleIds.find((value) => typeof value === "number")
 
   return typeof validId === "number" ? validId : null
+}
+
+function isUnauthorizedStatus(status: number): boolean {
+  return status === 401 || status === 403
+}
+
+function isLoginRequiredMessage(message: string | null | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  return message.includes("인증") || message.includes("로그인")
+}
+
+async function extractErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
+  try {
+    const errorData = await response.json()
+    return errorData?.message ?? errorData?.resultMessage ?? errorData?.msg ?? fallbackMessage
+  } catch {
+    return fallbackMessage
+  }
 }
 
 type ReplyFilesMap = Record<number, File[]>
@@ -319,6 +345,33 @@ export default function CommentSection({ postId }: CommentSectionProps) {
   const [newCommentFiles, setNewCommentFiles] = useState<File[]>([])
   const [replyFiles, setReplyFiles] = useState<ReplyFilesMap>({})
 
+  const [loginRequiredPopup, setLoginRequiredPopup] = useState<LoginRequiredPopupState>({
+    open: false,
+    message: "로그인이 필요한 기능입니다.",
+  })
+
+  const loginPath = useMemo(() => "/login", [])
+
+  const openLoginRequiredPopup = useCallback((message = "로그인이 필요한 기능입니다.") => {
+    setLoginRequiredPopup({
+      open: true,
+      message,
+    })
+  }, [])
+
+  const closeLoginRequiredPopup = useCallback(() => {
+    setLoginRequiredPopup((prev) => ({
+      ...prev,
+      open: false,
+    }))
+  }, [])
+
+  const moveToLoginPage = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.location.href = loginPath
+    }
+  }, [loginPath])
+
   const loadComments = useCallback(async () => {
     try {
       setLoading(true)
@@ -441,7 +494,13 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       })
 
       if (!response.ok) {
-        throw new Error("댓글 작성에 실패했습니다.")
+        if (isUnauthorizedStatus(response.status)) {
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
+
+        const message = await extractErrorMessage(response, "댓글 작성에 실패했습니다.")
+        throw new Error(message)
       }
 
       const createdComment = await response.json()
@@ -486,7 +545,13 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       })
 
       if (!response.ok) {
-        throw new Error("대댓글 작성에 실패했습니다.")
+        if (isUnauthorizedStatus(response.status)) {
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
+
+        const message = await extractErrorMessage(response, "대댓글 작성에 실패했습니다.")
+        throw new Error(message)
       }
 
       const createdReply = await response.json()
@@ -534,21 +599,16 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       })
 
       if (!response.ok) {
-        let message = "댓글 신고에 실패했습니다."
+        let message = await extractErrorMessage(response, "댓글 신고에 실패했습니다.")
 
-        try {
-          const errorData = await response.json()
-          message =
-            errorData?.message ??
-            errorData?.resultMessage ??
-            errorData?.msg ??
-            message
+        if (isUnauthorizedStatus(response.status) || isLoginRequiredMessage(message)) {
+          setError(null)
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
 
-          if (typeof message === "string" && message.includes("이미 신고")) {
-            message = "이미 신고한 댓글입니다."
-          }
-        } catch {
-          // 응답 본문이 JSON이 아니면 기본 메시지를 그대로 사용
+        if (typeof message === "string" && message.includes("이미 신고")) {
+          message = "이미 신고한 댓글입니다."
         }
 
         throw new Error(message)
@@ -557,7 +617,15 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       alert("댓글 신고가 접수되었습니다.")
       window.dispatchEvent(new CustomEvent("notifications-updated"))
     } catch (err) {
-      setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
+      const message = err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다."
+
+      if (isLoginRequiredMessage(message)) {
+        setError(null)
+        openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+        return
+      }
+
+      setError(message)
     } finally {
       setReportSubmittingId(null)
     }
@@ -575,7 +643,13 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       })
 
       if (!response.ok) {
-        throw new Error("댓글 삭제에 실패했습니다.")
+        if (isUnauthorizedStatus(response.status)) {
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
+
+        const message = await extractErrorMessage(response, "댓글 삭제에 실패했습니다.")
+        throw new Error(message)
       }
 
       if (openedReplyId === commentId) {
@@ -622,7 +696,13 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       })
 
       if (!response.ok) {
-        throw new Error("댓글 수정에 실패했습니다.")
+        if (isUnauthorizedStatus(response.status)) {
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
+
+        const message = await extractErrorMessage(response, "댓글 수정에 실패했습니다.")
+        throw new Error(message)
       }
 
       setEditingCommentId(null)
@@ -684,6 +764,31 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       )}
 
       {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+
+      {loginRequiredPopup.open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-lg">
+            <h3 className="text-lg font-semibold text-foreground">로그인 안내</h3>
+            <p className="mt-3 text-sm text-muted-foreground">{loginRequiredPopup.message}</p>
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeLoginRequiredPopup}
+                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={moveToLoginPage}
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+              >
+                로그인 하러가기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {!loading && !error && comments.length === 0 && (
         <p className="mt-4 text-sm text-muted-foreground">아직 댓글이 없습니다.</p>

--- a/frontend/components/interaction-buttons.tsx
+++ b/frontend/components/interaction-buttons.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import type React from "react"
 import { Heart, Bookmark } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -28,6 +28,11 @@ type BookmarkResponse = {
   postId: number
   bookmarked: boolean
   message?: string
+}
+
+type LoginRequiredPopupState = {
+  open: boolean
+  message: string
 }
 
 async function parseResponse(res: Response) {
@@ -62,6 +67,18 @@ function getAuthHeaders(): HeadersInit {
   return headers
 }
 
+function isUnauthorizedStatus(status: number): boolean {
+  return status === 401 || status === 403
+}
+
+function isLoginRequiredMessage(message: string | null | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  return message.includes("인증") || message.includes("로그인")
+}
+
 export default function InteractionButtons({
   postId,
   initialLiked = false,
@@ -74,6 +91,33 @@ export default function InteractionButtons({
   const [likeCount, setLikeCount] = useState(initialLikeCount)
   const [likeLoading, setLikeLoading] = useState(false)
   const [bookmarkLoading, setBookmarkLoading] = useState(false)
+
+  const [loginRequiredPopup, setLoginRequiredPopup] = useState<LoginRequiredPopupState>({
+    open: false,
+    message: "로그인이 필요한 기능입니다.",
+  })
+
+  const loginPath = useMemo(() => "/login", [])
+
+  const openLoginRequiredPopup = useCallback((message = "로그인이 필요한 기능입니다.") => {
+    setLoginRequiredPopup({
+      open: true,
+      message,
+    })
+  }, [])
+
+  const closeLoginRequiredPopup = useCallback(() => {
+    setLoginRequiredPopup((prev) => ({
+      ...prev,
+      open: false,
+    }))
+  }, [])
+
+  const moveToLoginPage = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.location.href = loginPath
+    }
+  }, [loginPath])
 
   useEffect(() => {
     setLiked(initialLiked)
@@ -91,7 +135,7 @@ export default function InteractionButtons({
     const auth = getAuthSnapshot()
 
     if (!auth.isLoggedIn) {
-      alert("인증이 필요합니다.")
+      openLoginRequiredPopup("로그인이 필요한 기능입니다.")
       return false
     }
 
@@ -119,15 +163,15 @@ export default function InteractionButtons({
       const parsed = await parseResponse(res)
 
       if (!res.ok) {
-        if (res.status === 401) {
-          alert("인증이 필요합니다.")
-          return
-        }
-
         const message =
           typeof parsed === "string"
             ? parsed || "좋아요 처리 실패"
             : parsed?.message || "좋아요 처리 실패"
+
+        if (isUnauthorizedStatus(res.status) || isLoginRequiredMessage(message)) {
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
 
         throw new Error(message)
       }
@@ -141,7 +185,14 @@ export default function InteractionButtons({
       window.dispatchEvent(new CustomEvent("notifications-updated"))
     } catch (error: any) {
       console.error("좋아요 처리 실패:", error)
-      alert(error.message || "좋아요 처리 실패")
+      const message = error?.message || "좋아요 처리 실패"
+
+      if (isLoginRequiredMessage(message)) {
+        openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+        return
+      }
+
+      alert(message)
     } finally {
       setLikeLoading(false)
     }
@@ -168,15 +219,15 @@ export default function InteractionButtons({
       const parsed = await parseResponse(res)
 
       if (!res.ok) {
-        if (res.status === 401) {
-          alert("인증이 필요합니다.")
-          return
-        }
-
         const message =
           typeof parsed === "string"
             ? parsed || "북마크 처리 실패"
             : parsed?.message || "북마크 처리 실패"
+
+        if (isUnauthorizedStatus(res.status) || isLoginRequiredMessage(message)) {
+          openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+          return
+        }
 
         throw new Error(message)
       }
@@ -190,7 +241,14 @@ export default function InteractionButtons({
       window.dispatchEvent(new CustomEvent("notifications-updated"))
     } catch (error: any) {
       console.error("북마크 처리 실패:", error)
-      alert(error.message || "북마크 처리 실패")
+      const message = error?.message || "북마크 처리 실패"
+
+      if (isLoginRequiredMessage(message)) {
+        openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+        return
+      }
+
+      alert(message)
     } finally {
       setBookmarkLoading(false)
     }
@@ -201,6 +259,30 @@ export default function InteractionButtons({
       className="flex items-center gap-2"
       onClick={(e) => e.stopPropagation()}
     >
+      {loginRequiredPopup.open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-lg">
+            <h3 className="text-lg font-semibold text-foreground">로그인 안내</h3>
+            <p className="mt-3 text-sm text-muted-foreground">{loginRequiredPopup.message}</p>
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeLoginRequiredPopup}
+                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={moveToLoginPage}
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+              >
+                로그인 하러가기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <Button
         type="button"
         variant={liked ? "default" : "outline"}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #176 

## 🛠️ 작업 내용
- 비로그인 상태에서 댓글 작성 시 일반 실패 메시지 대신 로그인 유도 팝업 표시

- 비로그인 상태에서 댓글 신고 시 일반 인증 오류 대신 로그인 유도 팝업 표시

- 비로그인 상태에서 게시글 신고 시 일반 인증 오류 대신 로그인 유도 팝업 표시

- 비로그인 상태에서 좋아요/북마크 클릭 시 기존 alert 대신 로그인 유도 팝업 표시

- 로그인 유도 팝업에 로그인 페이지 이동 버튼 추가

- 인증 관련 응답(`401`, `403`, `인증`, `로그인` 메시지)에 대한 프론트 분기 처리 공통화

## 🎯 리뷰 포인트
- 비로그인 상태에서 댓글 작성 / 댓글 신고 / 게시글 신고 / 좋아요 / 북마크가 모두 동일한 로그인 유도 UX로 동작하는지

- 인증 관련 에러만 팝업으로 분기되고, 일반 실패 케이스는 기존처럼 에러 처리되는지

- 로그인 페이지 이동 버튼이 정상적으로 `/login`으로 이동하는지

- 기존 로그인 상태에서 좋아요/북마크/신고/댓글 작성 기능이 영향 없이 동작하는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="641" height="497" alt="image" src="https://github.com/user-attachments/assets/ea2d1aec-0799-4f08-9f21-05c90d831cdd" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?