### PR TITLE
fix: 자기 신고 시 안내 팝업 UX 개선(#182)

### DIFF
--- a/frontend/app/posts/[postId]/page.tsx
+++ b/frontend/app/posts/[postId]/page.tsx
@@ -151,6 +151,22 @@ function isLoginRequiredMessage(message: string | null | undefined): boolean {
   return message.includes("인증") || message.includes("로그인")
 }
 
+function isSelfReportMessage(message: string | null | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  return message.includes("자신") || message.includes("본인") || message.includes("신고할 수 없습니다")
+}
+
+function isSelfReportPopupMessage(message: string | null | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  return message.includes("자신이 작성한") && message.includes("신고할 수 없습니다")
+}
+
 async function extractErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
   try {
     const errorData = await response.json()
@@ -287,6 +303,12 @@ export default function PostDetailPage() {
           return
         }
 
+        if (isSelfReportMessage(message)) {
+          setError(null)
+          openLoginRequiredPopup("자신이 작성한 게시글은 신고할 수 없습니다.")
+          return
+        }
+
         if (typeof message === "string" && message.includes("이미 신고")) {
           message = "이미 신고한 게시글입니다."
         }
@@ -302,6 +324,12 @@ export default function PostDetailPage() {
       if (isLoginRequiredMessage(message)) {
         setError(null)
         openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+        return
+      }
+
+      if (isSelfReportMessage(message)) {
+        setError(null)
+        openLoginRequiredPopup("자신이 작성한 게시글은 신고할 수 없습니다.")
         return
       }
 
@@ -353,22 +381,24 @@ export default function PostDetailPage() {
             {loginRequiredPopup.open && (
               <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
                 <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-lg">
-                  <h3 className="text-lg font-semibold text-foreground">로그인 안내</h3>
+                  <h3 className="text-lg font-semibold text-foreground">안내</h3>
                   <p className="mt-3 text-sm text-muted-foreground">{loginRequiredPopup.message}</p>
                   <div className="mt-6 flex justify-end gap-2">
+                    {!isSelfReportPopupMessage(loginRequiredPopup.message) && (
+                      <button
+                        type="button"
+                        onClick={closeLoginRequiredPopup}
+                        className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground"
+                      >
+                        취소
+                      </button>
+                    )}
                     <button
                       type="button"
-                      onClick={closeLoginRequiredPopup}
-                      className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground"
-                    >
-                      취소
-                    </button>
-                    <button
-                      type="button"
-                      onClick={moveToLoginPage}
+                      onClick={loginRequiredPopup.message.includes("로그인") ? moveToLoginPage : closeLoginRequiredPopup}
                       className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
                     >
-                      로그인 하러가기
+                      {loginRequiredPopup.message.includes("로그인") ? "로그인 하러가기" : "확인"}
                     </button>
                   </div>
                 </div>

--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -141,6 +141,22 @@ function isLoginRequiredMessage(message: string | null | undefined): boolean {
   return message.includes("인증") || message.includes("로그인")
 }
 
+function isSelfReportMessage(message: string | null | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  return message.includes("자신") || message.includes("본인") || message.includes("신고할 수 없습니다")
+}
+
+function isSelfReportPopupMessage(message: string | null | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  return message.includes("자신이 작성한") && message.includes("신고할 수 없습니다")
+}
+
 async function extractErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
   try {
     const errorData = await response.json()
@@ -607,6 +623,12 @@ export default function CommentSection({ postId }: CommentSectionProps) {
           return
         }
 
+        if (isSelfReportMessage(message)) {
+          setError(null)
+          openLoginRequiredPopup("자신이 작성한 댓글은 신고할 수 없습니다.")
+          return
+        }
+
         if (typeof message === "string" && message.includes("이미 신고")) {
           message = "이미 신고한 댓글입니다."
         }
@@ -622,6 +644,12 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       if (isLoginRequiredMessage(message)) {
         setError(null)
         openLoginRequiredPopup("로그인이 필요한 기능입니다.")
+        return
+      }
+
+      if (isSelfReportMessage(message)) {
+        setError(null)
+        openLoginRequiredPopup("자신이 작성한 댓글은 신고할 수 없습니다.")
         return
       }
 
@@ -768,22 +796,24 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       {loginRequiredPopup.open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
           <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-lg">
-            <h3 className="text-lg font-semibold text-foreground">로그인 안내</h3>
+            <h3 className="text-lg font-semibold text-foreground">안내</h3>
             <p className="mt-3 text-sm text-muted-foreground">{loginRequiredPopup.message}</p>
             <div className="mt-6 flex justify-end gap-2">
+              {!isSelfReportPopupMessage(loginRequiredPopup.message) && (
+                <button
+                  type="button"
+                  onClick={closeLoginRequiredPopup}
+                  className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground"
+                >
+                  취소
+                </button>
+              )}
               <button
                 type="button"
-                onClick={closeLoginRequiredPopup}
-                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground"
-              >
-                취소
-              </button>
-              <button
-                type="button"
-                onClick={moveToLoginPage}
+                onClick={loginRequiredPopup.message.includes("로그인") ? moveToLoginPage : closeLoginRequiredPopup}
                 className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
               >
-                로그인 하러가기
+                {loginRequiredPopup.message.includes("로그인") ? "로그인 하러가기" : "확인"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## 📌 관련 이슈

Closes #182 

## 🛠️ 작업 내용
- 자기 게시글 신고 시 일반 에러 문구 대신 안내 팝업이 표시되도록 수정

- 자기 댓글 신고 시 일반 에러 문구 대신 안내 팝업이 표시되도록 수정

- 자기 신고 불가 안내 팝업은 `확인` 버튼만 노출되도록 분기 처리

- 로그인 필요 안내 팝업은 기존처럼 `취소` + `로그인 하러가기` 버튼이 유지되도록 수정

- 게시글 신고와 댓글 신고의 실패 안내 UX를 동일하게 정리

## 🎯 리뷰 포인트
- 자기 게시글/댓글 신고 시 더 이상 본문 또는 상단에 일반 에러 문구가 노출되지 않는지

- 자기 신고 불가 안내 팝업에서는 `확인` 버튼만 보이는지

- 로그인 필요 안내 팝업에서는 기존처럼 `취소` + `로그인 하러가기`가 유지되는지

- 게시글 신고와 댓글 신고가 동일한 UX로 동작하는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="388" height="206" alt="image" src="https://github.com/user-attachments/assets/612eea06-2d7d-4de2-9c35-d341eea7b44a" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?