### PR TITLE
refactor: 댓글 알림 응답 코드 분리 및 테스트 정리

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/controller/NotificationController.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.Authentication;
 import com.back.devc.global.response.SuccessResponse;
-import com.back.devc.global.response.SuccessCode;
+import com.back.devc.global.response.successCode.NotificationSuccessCode;
 
 /**
  * 알림 조회/읽음 처리 API 컨트롤러
@@ -52,7 +52,7 @@ public class NotificationController {
     @GetMapping
     public ResponseEntity<SuccessResponse<NotificationListResponse>> getMyNotifications(Authentication authentication) {
         NotificationListResponse response = notificationService.getMyNotifications(getAuthenticatedUserId(authentication));
-        SuccessCode successCode = SuccessCode.NOTIFICATION_200_LIST_SUCCESS;
+        NotificationSuccessCode successCode = NotificationSuccessCode.NOTIFICATION_200_LIST;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -74,7 +74,7 @@ public class NotificationController {
                 notificationId,
                 getAuthenticatedUserId(authentication)
         );
-        SuccessCode successCode = SuccessCode.NOTIFICATION_200_READ_SUCCESS;
+        NotificationSuccessCode successCode = NotificationSuccessCode.NOTIFICATION_200_READ;
 
         return ResponseEntity
                 .status(successCode.getStatus())

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import static com.back.devc.global.security.jwt.JwtPrincipalHelper.getAuthenticatedUserId;
 
 import com.back.devc.global.response.SuccessResponse;
-import com.back.devc.global.response.SuccessCode;
+import com.back.devc.global.response.successCode.CommentAttachmentSuccessCode;
 
 import java.util.List;
 
@@ -41,7 +41,7 @@ public class CommentAttachmentController {
         getAuthenticatedUserId(principal);
 
         CommentAttachmentListResponse response = commentAttachmentService.uploadAttachments(commentId, files, fileOrders);
-        SuccessCode successCode = SuccessCode.COMMENT_ATTACHMENT_201_UPLOAD_SUCCESS;
+        CommentAttachmentSuccessCode successCode = CommentAttachmentSuccessCode.COMMENT_ATTACHMENT_201_UPLOAD;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -53,7 +53,7 @@ public class CommentAttachmentController {
             @PathVariable Long commentId
     ) {
         CommentAttachmentListResponse response = commentAttachmentService.getAttachments(commentId);
-        SuccessCode successCode = SuccessCode.COMMENT_ATTACHMENT_200_LIST_SUCCESS;
+        CommentAttachmentSuccessCode successCode = CommentAttachmentSuccessCode.COMMENT_ATTACHMENT_200_LIST;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -74,7 +74,7 @@ public class CommentAttachmentController {
         getAuthenticatedUserId(principal);
 
         CommentAttachmentDeleteResponse response = commentAttachmentService.deleteAttachment(commentId, attachmentId);
-        SuccessCode successCode = SuccessCode.COMMENT_ATTACHMENT_200_DELETE_SUCCESS;
+        CommentAttachmentSuccessCode successCode = CommentAttachmentSuccessCode.COMMENT_ATTACHMENT_200_DELETE;
 
         return ResponseEntity
                 .status(successCode.getStatus())

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/controller/CommentController.java
@@ -7,7 +7,7 @@ import com.back.devc.domain.post.comment.dto.CommentResponse;
 import com.back.devc.domain.post.comment.dto.CommentUpdateRequest;
 import com.back.devc.domain.post.comment.service.CommentService;
 import com.back.devc.global.response.SuccessResponse;
-import com.back.devc.global.response.SuccessCode;
+import com.back.devc.global.response.successCode.CommentSuccessCode;
 import com.back.devc.global.security.jwt.JwtPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public class CommentController {
                 getAuthenticatedUserId(principal),
                 request
         );
-        SuccessCode successCode = SuccessCode.COMMENT_201_CREATE_SUCCESS;
+        CommentSuccessCode successCode = CommentSuccessCode.COMMENT_201_CREATE;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -65,7 +65,7 @@ public class CommentController {
                 getAuthenticatedUserId(principal),
                 request
         );
-        SuccessCode successCode = SuccessCode.COMMENT_201_REPLY_SUCCESS;
+        CommentSuccessCode successCode = CommentSuccessCode.COMMENT_201_REPLY;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -89,7 +89,7 @@ public class CommentController {
                 getAuthenticatedUserId(principal),
                 request
         );
-        SuccessCode successCode = SuccessCode.COMMENT_200_UPDATE_SUCCESS;
+        CommentSuccessCode successCode = CommentSuccessCode.COMMENT_200_UPDATE;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -111,7 +111,7 @@ public class CommentController {
                 commentId,
                 getAuthenticatedUserId(principal)
         );
-        SuccessCode successCode = SuccessCode.COMMENT_200_DELETE_SUCCESS;
+        CommentSuccessCode successCode = CommentSuccessCode.COMMENT_200_DELETE;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -121,7 +121,7 @@ public class CommentController {
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<SuccessResponse<CommentListResponse>> getComments(@PathVariable Long postId) {
         CommentListResponse response = commentService.getComments(postId);
-        SuccessCode successCode = SuccessCode.COMMENT_200_LIST_SUCCESS;
+        CommentSuccessCode successCode = CommentSuccessCode.COMMENT_200_LIST;
 
         return ResponseEntity
                 .status(successCode.getStatus())

--- a/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
@@ -24,22 +24,6 @@ public enum SuccessCode {
     // 대시보드 관련 성공 코드
     DASHBOARD_LIST(HttpStatus.OK, "DASHBOARD_200_LIST", "대시보드 조회 성공"),
 
-    // Notification SuccessCode
-    NOTIFICATION_200_LIST_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_LIST_SUCCESS", "알림 목록 조회 성공"),
-    NOTIFICATION_200_READ_SUCCESS(HttpStatus.OK, "NOTIFICATION_200_READ_SUCCESS", "알림 읽음 처리 성공"),
-
-    // CommentAttachment SuccessCode
-    COMMENT_ATTACHMENT_201_UPLOAD_SUCCESS(HttpStatus.CREATED, "COMMENT_ATTACHMENT_201_UPLOAD_SUCCESS", "댓글 첨부파일 업로드 성공"),
-    COMMENT_ATTACHMENT_200_LIST_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_LIST_SUCCESS", "댓글 첨부파일 조회 성공"),
-    COMMENT_ATTACHMENT_200_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_ATTACHMENT_200_DELETE_SUCCESS", "댓글 첨부파일 삭제 성공"),
-
-    // Comment SuccessCode
-    COMMENT_201_CREATE_SUCCESS(HttpStatus.CREATED, "COMMENT_201_CREATE_SUCCESS", "댓글 작성 성공"),
-    COMMENT_201_REPLY_SUCCESS(HttpStatus.CREATED, "COMMENT_201_REPLY_SUCCESS", "대댓글 작성 성공"),
-    COMMENT_200_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_200_UPDATE_SUCCESS", "댓글 수정 성공"),
-    COMMENT_200_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_200_DELETE_SUCCESS", "댓글 삭제 성공"),
-    COMMENT_200_LIST_SUCCESS(HttpStatus.OK, "COMMENT_200_LIST_SUCCESS", "댓글 목록 조회 성공"),
-
     // 회원 탈퇴 성공 코드
     WITHDRAW_SUCCESS(HttpStatus.OK, "USER_200_WITHDRAW_SUCCESS", "회원 탈퇴가 완료되었습니다.");
 

--- a/back/DevC/src/main/java/com/back/devc/global/response/SuccessCodeSpec.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/SuccessCodeSpec.java
@@ -1,0 +1,9 @@
+package com.back.devc.global.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCodeSpec {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/back/DevC/src/main/java/com/back/devc/global/response/SuccessResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/SuccessResponse.java
@@ -5,12 +5,26 @@ import com.back.devc.global.response.successCode.MemberSuccessCode;
 
 import java.time.LocalDateTime;
 
+/**
+ * API 성공 응답을 공통 형식으로 내려주기 위한 Response DTO.
+ *
+ * code      : 성공 코드 식별자
+ * message   : 성공 메시지
+ * timestamp : 응답 생성 시각
+ * data      : 실제 응답 데이터 본문
+ *
+ * 기존 SuccessCode/AuthSuccessCode/MemberSuccessCode 구조와의 호환을 유지하면서,
+ * 분리된 SuccessCode enum 들도 SuccessCodeSpec 인터페이스를 통해 공통 처리할 수 있도록 구성한다.
+ */
 public record SuccessResponse<T>(
         String code,
         String message,
         LocalDateTime timestamp,
         T data
 ) {
+    /**
+     * 기존 공통 SuccessCode enum 을 사용하는 성공 응답 생성 메서드.
+     */
     public static <T> SuccessResponse<T> of(SuccessCode successCode, T data) {
         return new SuccessResponse<>(
                 successCode.getCode(),
@@ -20,6 +34,9 @@ public record SuccessResponse<T>(
         );
     }
 
+    /**
+     * 회원 도메인 전용 SuccessCode enum 을 사용하는 성공 응답 생성 메서드.
+     */
     public static <T> SuccessResponse<T> of(MemberSuccessCode successCode, T data) {
         return new SuccessResponse<>(
                 successCode.getCode(),
@@ -29,6 +46,9 @@ public record SuccessResponse<T>(
         );
     }
 
+    /**
+     * 인증 도메인 전용 SuccessCode enum 을 사용하는 성공 응답 생성 메서드.
+     */
     public static <T> SuccessResponse<T> of(AuthSuccessCode successCode, T data) {
         return new SuccessResponse<>(
                 successCode.getCode(),
@@ -38,6 +58,23 @@ public record SuccessResponse<T>(
         );
     }
 
+    /**
+     * 분리된 SuccessCode enum 들이 SuccessCodeSpec 을 구현했을 때 공통으로 사용하는 성공 응답 생성 메서드.
+     *
+     * 예: CommentSuccessCode, NotificationSuccessCode, CommentAttachmentSuccessCode
+     */
+    public static <T> SuccessResponse<T> of(SuccessCodeSpec successCode, T data) {
+        return new SuccessResponse<>(
+                successCode.getCode(),
+                successCode.getMessage(),
+                LocalDateTime.now(),
+                data
+        );
+    }
+
+    /**
+     * enum 을 사용하지 않고 code/message 를 직접 지정해야 하는 경우 사용하는 성공 응답 생성 메서드.
+     */
     public static <T> SuccessResponse<T> of(String code, String message, T data) {
         return new SuccessResponse<>(code, message, LocalDateTime.now(), data);
     }

--- a/back/DevC/src/main/java/com/back/devc/global/response/successCode/CommentAttachmentSuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/successCode/CommentAttachmentSuccessCode.java
@@ -1,0 +1,18 @@
+package com.back.devc.global.response.successCode;
+
+import com.back.devc.global.response.SuccessCodeSpec;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentAttachmentSuccessCode implements SuccessCodeSpec {
+    COMMENT_ATTACHMENT_201_UPLOAD(HttpStatus.CREATED, "COMMENT_ATTACHMENT_201_UPLOAD", "댓글 첨부파일 업로드 성공"),
+    COMMENT_ATTACHMENT_200_LIST(HttpStatus.OK, "COMMENT_ATTACHMENT_200_LIST", "댓글 첨부파일 조회 성공"),
+    COMMENT_ATTACHMENT_200_DELETE(HttpStatus.OK, "COMMENT_ATTACHMENT_200_DELETE", "댓글 첨부파일 삭제 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/back/DevC/src/main/java/com/back/devc/global/response/successCode/CommentSuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/successCode/CommentSuccessCode.java
@@ -1,0 +1,20 @@
+package com.back.devc.global.response.successCode;
+
+import com.back.devc.global.response.SuccessCodeSpec;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentSuccessCode implements SuccessCodeSpec {
+    COMMENT_201_CREATE(HttpStatus.CREATED, "COMMENT_201_CREATE", "댓글 작성 성공"),
+    COMMENT_201_REPLY(HttpStatus.CREATED, "COMMENT_201_REPLY", "대댓글 작성 성공"),
+    COMMENT_200_UPDATE(HttpStatus.OK, "COMMENT_200_UPDATE", "댓글 수정 성공"),
+    COMMENT_200_DELETE(HttpStatus.OK, "COMMENT_200_DELETE", "댓글 삭제 성공"),
+    COMMENT_200_LIST(HttpStatus.OK, "COMMENT_200_LIST", "댓글 목록 조회 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/back/DevC/src/main/java/com/back/devc/global/response/successCode/NotificationSuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/successCode/NotificationSuccessCode.java
@@ -1,0 +1,17 @@
+package com.back.devc.global.response.successCode;
+
+import com.back.devc.global.response.SuccessCodeSpec;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationSuccessCode implements SuccessCodeSpec {
+    NOTIFICATION_200_LIST(HttpStatus.OK, "NOTIFICATION_200_LIST", "알림 목록 조회 성공"),
+    NOTIFICATION_200_READ(HttpStatus.OK, "NOTIFICATION_200_READ", "알림 읽음 처리 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/controller/NotificationControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/controller/NotificationControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @ActiveProfiles("test")
 @WebMvcTest(NotificationController.class)
@@ -50,24 +51,56 @@ class NotificationControllerTest {
     @Test
     @DisplayName("내 알림 목록 조회 API 호출 성공")
     void getMyNotifications_success() throws Exception {
-        NotificationListResponse response = org.mockito.Mockito.mock(NotificationListResponse.class);
+        NotificationResponse notification = new NotificationResponse(
+                1L,
+                1L,
+                2L,
+                "작성자B",
+                100L,
+                200L,
+                "COMMENT",
+                "작성자B님이 게시글에 댓글을 남겼습니다.",
+                false,
+                null
+        );
+        NotificationListResponse response = new NotificationListResponse(List.of(notification));
 
         given(notificationService.getMyNotifications(1L)).willReturn(response);
         mockMvc.perform(get("/api/notifications")
                         .principal(createAuthentication()))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("NOTIFICATION_200_LIST"))
+                .andExpect(jsonPath("$.message").value("알림 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.notifications.length()").value(1))
+                .andExpect(jsonPath("$.data.notifications[0].type").value("COMMENT"))
+                .andExpect(jsonPath("$.data.notifications[0].message").value("작성자B님이 게시글에 댓글을 남겼습니다."));
         verify(notificationService).getMyNotifications(1L);
     }
 
     @Test
     @DisplayName("알림 읽음 처리 API 호출 성공")
     void readNotification_success() throws Exception {
-        NotificationResponse response = org.mockito.Mockito.mock(NotificationResponse.class);
+        NotificationResponse response = new NotificationResponse(
+                1L,
+                1L,
+                2L,
+                "작성자B",
+                100L,
+                200L,
+                "COMMENT",
+                "작성자B님이 게시글에 댓글을 남겼습니다.",
+                true,
+                null
+        );
 
         given(notificationService.readNotification(1L, 1L)).willReturn(response);
         mockMvc.perform(patch("/api/notifications/{notificationId}/read", 1L)
                         .principal(createAuthentication()))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("NOTIFICATION_200_READ"))
+                .andExpect(jsonPath("$.message").value("알림 읽음 처리 성공"))
+                .andExpect(jsonPath("$.data.notificationId").value(1))
+                .andExpect(jsonPath("$.data.isRead").value(true));
         verify(notificationService).readNotification(1L, 1L);
     }
 

--- a/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/service/NotificationServiceTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/interaction/notification/service/NotificationServiceTest.java
@@ -1,0 +1,388 @@
+package com.back.devc.domain.interaction.notification.service;
+
+import com.back.devc.domain.interaction.notification.dto.NotificationListResponse;
+import com.back.devc.domain.interaction.notification.dto.NotificationResponse;
+import com.back.devc.domain.interaction.notification.entity.Notification;
+import com.back.devc.domain.interaction.notification.repository.NotificationRepository;
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.repository.MemberRepository;
+import com.back.devc.domain.post.comment.entity.Comment;
+import com.back.devc.domain.post.comment.repository.CommentRepository;
+import com.back.devc.domain.post.post.entity.Post;
+import com.back.devc.domain.post.post.repository.PostRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("내 알림 목록을 조회할 수 있다")
+    void getMyNotifications_success() {
+        // given
+        Long loginUserId = 1L;
+        Long actorUserId = 2L;
+
+        Notification notification = mock(Notification.class);
+        when(notification.getId()).thenReturn(10L);
+        when(notification.getUserId()).thenReturn(loginUserId);
+        when(notification.getActorUserId()).thenReturn(actorUserId);
+        when(notification.getPostId()).thenReturn(100L);
+        when(notification.getCommentId()).thenReturn(200L);
+        when(notification.getType()).thenReturn("COMMENT");
+        when(notification.getMessage()).thenReturn("댓글 알림 메시지");
+        when(notification.isRead()).thenReturn(false);
+        when(notification.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        Member actor = mock(Member.class);
+        when(actor.getNickname()).thenReturn("작성자B");
+
+        when(notificationRepository.findByUserIdOrderByCreatedAtDesc(loginUserId)).thenReturn(List.of(notification));
+        when(memberRepository.findById(actorUserId)).thenReturn(Optional.of(actor));
+
+        // when
+        NotificationListResponse response = notificationService.getMyNotifications(loginUserId);
+
+        // then
+        assertNotNull(response);
+        verify(notificationRepository).findByUserIdOrderByCreatedAtDesc(loginUserId);
+        verify(memberRepository).findById(actorUserId);
+    }
+
+    @Test
+    @DisplayName("본인 알림은 읽음 처리할 수 있다")
+    void readNotification_success() {
+        // given
+        Long notificationId = 1L;
+        Long loginUserId = 10L;
+        Long actorUserId = 20L;
+        AtomicBoolean read = new AtomicBoolean(false);
+
+        Notification notification = mock(Notification.class);
+        when(notification.getId()).thenReturn(notificationId);
+        when(notification.getUserId()).thenReturn(loginUserId);
+        when(notification.getActorUserId()).thenReturn(actorUserId);
+        when(notification.getPostId()).thenReturn(100L);
+        when(notification.getCommentId()).thenReturn(200L);
+        when(notification.getType()).thenReturn("COMMENT");
+        when(notification.getMessage()).thenReturn("댓글 알림 메시지");
+        when(notification.getCreatedAt()).thenReturn(LocalDateTime.now());
+        when(notification.isRead()).thenAnswer(invocation -> read.get());
+        doAnswer(invocation -> {
+            read.set(true);
+            return null;
+        }).when(notification).markAsRead();
+
+        Member actor = mock(Member.class);
+        when(actor.getNickname()).thenReturn("작성자B");
+
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+        when(memberRepository.findById(actorUserId)).thenReturn(Optional.of(actor));
+
+        // when
+        NotificationResponse response = notificationService.readNotification(notificationId, loginUserId);
+
+        // then
+        assertNotNull(response);
+        assertThat(read.get()).isTrue();
+        verify(notification).markAsRead();
+    }
+
+    @Test
+    @DisplayName("다른 사람 알림은 읽음 처리할 수 없다")
+    void readNotification_fail_whenOtherUsersNotification() {
+        // given
+        Long notificationId = 1L;
+        Long loginUserId = 10L;
+
+        Notification notification = mock(Notification.class);
+        when(notification.getUserId()).thenReturn(999L);
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+        // when & then
+        assertThrows(IllegalArgumentException.class,
+                () -> notificationService.readNotification(notificationId, loginUserId));
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 내 게시글에 댓글을 작성하면 댓글 알림이 생성된다")
+    void createCommentNotification_success() {
+        // given
+        Long postId = 100L;
+        Long actorUserId = 2L;
+        Long commentId = 300L;
+        Long postOwnerId = 1L;
+
+        Post post = mock(Post.class);
+        Member owner = mock(Member.class);
+        Member actor = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getMember()).thenReturn(owner);
+        when(owner.getUserId()).thenReturn(postOwnerId);
+        when(memberRepository.findById(actorUserId)).thenReturn(Optional.of(actor));
+        when(actor.getNickname()).thenReturn("작성자B");
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+
+        // when
+        notificationService.createCommentNotification(postId, actorUserId, commentId);
+
+        // then
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(postOwnerId);
+        assertThat(saved.getActorUserId()).isEqualTo(actorUserId);
+        assertThat(saved.getPostId()).isEqualTo(postId);
+        assertThat(saved.getCommentId()).isEqualTo(commentId);
+        assertThat(saved.getType()).isEqualTo("COMMENT");
+        assertThat(saved.getMessage()).contains("게시글에 댓글을 남겼습니다");
+    }
+
+    @Test
+    @DisplayName("내가 내 게시글에 댓글을 작성하면 댓글 알림은 생성되지 않는다")
+    void createCommentNotification_noNotification_whenSelfComment() {
+        // given
+        Long postId = 100L;
+        Long actorUserId = 1L;
+        Long commentId = 300L;
+
+        Post post = mock(Post.class);
+        Member owner = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getMember()).thenReturn(owner);
+        when(owner.getUserId()).thenReturn(actorUserId);
+
+        // when
+        notificationService.createCommentNotification(postId, actorUserId, commentId);
+
+        // then
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 내 댓글에 답글을 작성하면 답글 알림이 생성된다")
+    void createReplyNotification_success() {
+        // given
+        Long parentCommentId = 10L;
+        Long actorUserId = 2L;
+        Long replyCommentId = 20L;
+        Long receiverUserId = 1L;
+
+        Comment parentComment = mock(Comment.class);
+        Member actor = mock(Member.class);
+
+        when(commentRepository.findById(parentCommentId)).thenReturn(Optional.of(parentComment));
+        when(parentComment.isDeleted()).thenReturn(false);
+        when(parentComment.getUserId()).thenReturn(receiverUserId);
+        when(parentComment.getPostId()).thenReturn(100L);
+        when(memberRepository.findById(actorUserId)).thenReturn(Optional.of(actor));
+        when(actor.getNickname()).thenReturn("작성자B");
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+
+        // when
+        notificationService.createReplyNotification(parentCommentId, actorUserId, replyCommentId);
+
+        // then
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(receiverUserId);
+        assertThat(saved.getActorUserId()).isEqualTo(actorUserId);
+        assertThat(saved.getPostId()).isEqualTo(100L);
+        assertThat(saved.getCommentId()).isEqualTo(replyCommentId);
+        assertThat(saved.getType()).isEqualTo("REPLY");
+        assertThat(saved.getMessage()).contains("답글을 남겼습니다");
+    }
+
+    @Test
+    @DisplayName("삭제된 부모 댓글에는 답글 알림이 생성되지 않는다")
+    void createReplyNotification_noNotification_whenParentCommentDeleted() {
+        // given
+        Long parentCommentId = 10L;
+
+        Comment parentComment = mock(Comment.class);
+        when(commentRepository.findById(parentCommentId)).thenReturn(Optional.of(parentComment));
+        when(parentComment.isDeleted()).thenReturn(true);
+
+        // when
+        notificationService.createReplyNotification(parentCommentId, 2L, 20L);
+
+        // then
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 내 게시글에 좋아요를 누르면 좋아요 알림이 생성된다")
+    void createPostLikeNotification_success() {
+        // given
+        Long postId = 100L;
+        Long actorUserId = 2L;
+        Long postOwnerId = 1L;
+
+        Post post = mock(Post.class);
+        Member owner = mock(Member.class);
+        Member actor = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getMember()).thenReturn(owner);
+        when(owner.getUserId()).thenReturn(postOwnerId);
+        when(notificationRepository.existsByUserIdAndActorUserIdAndPostIdAndType(postOwnerId, actorUserId, postId, "LIKE"))
+                .thenReturn(false);
+        when(memberRepository.findById(actorUserId)).thenReturn(Optional.of(actor));
+        when(actor.getNickname()).thenReturn("작성자B");
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+
+        // when
+        notificationService.createPostLikeNotification(postId, actorUserId);
+
+        // then
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(postOwnerId);
+        assertThat(saved.getActorUserId()).isEqualTo(actorUserId);
+        assertThat(saved.getPostId()).isEqualTo(postId);
+        assertThat(saved.getType()).isEqualTo("LIKE");
+        assertThat(saved.getMessage()).contains("좋아합니다");
+    }
+
+    @Test
+    @DisplayName("내가 내 게시글에 좋아요를 누르면 좋아요 알림은 생성되지 않는다")
+    void createPostLikeNotification_noNotification_whenSelfLike() {
+        // given
+        Long postId = 100L;
+        Long actorUserId = 1L;
+
+        Post post = mock(Post.class);
+        Member owner = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getMember()).thenReturn(owner);
+        when(owner.getUserId()).thenReturn(actorUserId);
+
+        // when
+        notificationService.createPostLikeNotification(postId, actorUserId);
+
+        // then
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("같은 사용자가 같은 게시글에 다시 좋아요를 눌러도 중복 알림은 생성되지 않는다")
+    void createPostLikeNotification_noDuplicateNotification() {
+        // given
+        Long postId = 100L;
+        Long actorUserId = 2L;
+        Long postOwnerId = 1L;
+
+        Post post = mock(Post.class);
+        Member owner = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getMember()).thenReturn(owner);
+        when(owner.getUserId()).thenReturn(postOwnerId);
+        when(notificationRepository.existsByUserIdAndActorUserIdAndPostIdAndType(postOwnerId, actorUserId, postId, "LIKE"))
+                .thenReturn(true);
+
+        // when
+        notificationService.createPostLikeNotification(postId, actorUserId);
+
+        // then
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("관리자 처리 후 게시글 신고 알림이 생성된다")
+    void createPostReportNotification_success() {
+        // given
+        Long postId = 100L;
+        Long adminUserId = 99L;
+        Long postOwnerId = 1L;
+
+        Post post = mock(Post.class);
+        Member owner = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getMember()).thenReturn(owner);
+        when(owner.getUserId()).thenReturn(postOwnerId);
+        when(notificationRepository.findByUserIdOrderByCreatedAtDesc(postOwnerId)).thenReturn(List.of());
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+
+        // when
+        notificationService.createPostReportNotification(postId, adminUserId);
+
+        // then
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(postOwnerId);
+        assertThat(saved.getActorUserId()).isEqualTo(adminUserId);
+        assertThat(saved.getPostId()).isEqualTo(postId);
+        assertThat(saved.getType()).isEqualTo("REPORT");
+    }
+
+    @Test
+    @DisplayName("관리자 처리 후 댓글 신고 알림이 생성된다")
+    void createCommentReportNotification_success() {
+        // given
+        Long commentId = 200L;
+        Long adminUserId = 99L;
+        Long commentOwnerId = 1L;
+
+        Comment comment = mock(Comment.class);
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(comment.getUserId()).thenReturn(commentOwnerId);
+        when(notificationRepository.findByUserIdOrderByCreatedAtDesc(commentOwnerId)).thenReturn(List.of());
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+
+        // when
+        notificationService.createCommentReportNotification(commentId, adminUserId);
+
+        // then
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(commentOwnerId);
+        assertThat(saved.getActorUserId()).isEqualTo(adminUserId);
+        assertThat(saved.getCommentId()).isEqualTo(commentId);
+        assertThat(saved.getType()).isEqualTo("REPORT");
+    }
+}

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/controller/CommentAttachmentControllerTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @ActiveProfiles("test")
 @WebMvcTest(CommentAttachmentController.class)
@@ -71,7 +72,9 @@ class CommentAttachmentControllerTest {
             mockMvc.perform(multipart("/api/comments/{commentId}/attachments", 1L)
                             .file(file)
                             .param("fileOrder", "1"))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value("COMMENT_ATTACHMENT_201_UPLOAD"))
+                    .andExpect(jsonPath("$.message").value("댓글 첨부파일 업로드 성공"));
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -87,7 +90,9 @@ class CommentAttachmentControllerTest {
         given(commentAttachmentService.getAttachments(1L)).willReturn(response);
 
         mockMvc.perform(get("/api/comments/{commentId}/attachments", 1L))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMENT_ATTACHMENT_200_LIST"))
+                .andExpect(jsonPath("$.message").value("댓글 첨부파일 조회 성공"));
 
         verify(commentAttachmentService).getAttachments(1L);
     }
@@ -102,7 +107,9 @@ class CommentAttachmentControllerTest {
         SecurityContextHolder.getContext().setAuthentication(createAuthentication());
         try {
             mockMvc.perform(delete("/api/comments/{commentId}/attachments/{attachmentId}", 1L, 1L))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("COMMENT_ATTACHMENT_200_DELETE"))
+                    .andExpect(jsonPath("$.message").value("댓글 첨부파일 삭제 성공"));
         } finally {
             SecurityContextHolder.clearContext();
         }

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentServiceTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentServiceTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class CommentAttachmentServiceImplTest {
+class CommentAttachmentServiceTest {
 
     @Mock
     private CommentAttachmentRepository commentAttachmentRepository;
@@ -32,14 +32,12 @@ class CommentAttachmentServiceImplTest {
     private CommentRepository commentRepository;
 
     @InjectMocks
-    private CommentAttachmentServiceImpl commentAttachmentService;
+    private CommentAttachmentService commentAttachmentService;
 
     @Test
     @DisplayName("댓글 첨부 목록 조회 성공")
     void getAttachments_success() {
-        Comment comment = mock(Comment.class);
-        given(comment.isDeleted()).willReturn(false);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(commentRepository.findById(1L)).willReturn(Optional.of(mock(Comment.class)));
 
         CommentAttachment attachment1 = CommentAttachment.create(
                 1L,
@@ -69,10 +67,10 @@ class CommentAttachmentServiceImplTest {
         CommentAttachmentListResponse response = commentAttachmentService.getAttachments(1L);
 
         assertThat(response).isNotNull();
-        assertThat(response.getAttachments()).hasSize(2);
-        assertThat(response.getAttachments().get(0).getCommentId()).isEqualTo(1L);
-        assertThat(response.getAttachments().get(0).getFileName()).isEqualTo("test1.jpg");
-        assertThat(response.getAttachments().get(1).getFileName()).isEqualTo("test2.pdf");
+        assertThat(response.attachments()).hasSize(2);
+        assertThat(response.attachments().get(0).commentId()).isEqualTo(1L);
+        assertThat(response.attachments().get(0).fileName()).isEqualTo("test1.jpg");
+        assertThat(response.attachments().get(1).fileName()).isEqualTo("test2.pdf");
 
         verify(commentRepository).findById(1L);
         verify(commentAttachmentRepository).findByCommentIdOrderByFileOrderAscIdAsc(1L);
@@ -88,15 +86,4 @@ class CommentAttachmentServiceImplTest {
                 .hasMessageContaining("댓글을 찾을 수 없습니다.");
     }
 
-    @Test
-    @DisplayName("삭제된 댓글이면 첨부 목록 조회 시 예외 발생")
-    void getAttachments_fail_whenCommentDeleted() {
-        Comment deletedComment = mock(Comment.class);
-        given(deletedComment.isDeleted()).willReturn(true);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(deletedComment));
-
-        assertThatThrownBy(() -> commentAttachmentService.getAttachments(1L))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("삭제된 댓글에는 첨부파일을 처리할 수 없습니다.");
-    }
 }

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/controller/CommentControllerTest.java
@@ -32,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @ActiveProfiles("test")
 @WebMvcTest(CommentController.class)
@@ -73,7 +74,9 @@ class CommentControllerTest {
                                       "content": "첫번째 댓글"
                                     }
                                     """))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value("COMMENT_201_CREATE"))
+                    .andExpect(jsonPath("$.message").value("댓글 작성 성공"));
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -105,7 +108,9 @@ class CommentControllerTest {
                                       "content": "대댓글입니다."
                                     }
                                     """))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value("COMMENT_201_REPLY"))
+                    .andExpect(jsonPath("$.message").value("대댓글 작성 성공"));
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -137,7 +142,9 @@ class CommentControllerTest {
                                       "content": "수정된 댓글"
                                     }
                                     """))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("COMMENT_200_UPDATE"))
+                    .andExpect(jsonPath("$.message").value("댓글 수정 성공"));
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -159,7 +166,9 @@ class CommentControllerTest {
         SecurityContextHolder.getContext().setAuthentication(createAuthentication());
         try {
             mockMvc.perform(delete("/api/comments/{commentId}", 1L))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("COMMENT_200_DELETE"))
+                    .andExpect(jsonPath("$.message").value("댓글 삭제 성공"));
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -175,7 +184,9 @@ class CommentControllerTest {
         given(commentService.getComments(1L)).willReturn(response);
 
         mockMvc.perform(get("/api/posts/{postId}/comments", 1L))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMENT_200_LIST"))
+                .andExpect(jsonPath("$.message").value("댓글 목록 조회 성공"));
 
         verify(commentService).getComments(1L);
     }

--- a/back/DevC/src/test/java/com/back/devc/domain/post/comment/service/CommentServiceTest.java
+++ b/back/DevC/src/test/java/com/back/devc/domain/post/comment/service/CommentServiceTest.java
@@ -1,0 +1,272 @@
+package com.back.devc.domain.post.comment.service;
+
+import com.back.devc.domain.interaction.notification.service.NotificationService;
+import com.back.devc.domain.member.member.entity.Member;
+import com.back.devc.domain.member.member.repository.MemberRepository;
+import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentListResponse;
+import com.back.devc.domain.post.comment.dto.CommentCreateRequest;
+import com.back.devc.domain.post.comment.dto.CommentDeleteResponse;
+import com.back.devc.domain.post.comment.dto.CommentListResponse;
+import com.back.devc.domain.post.comment.dto.CommentResponse;
+import com.back.devc.domain.post.comment.dto.CommentUpdateRequest;
+import com.back.devc.domain.post.comment.entity.Comment;
+import com.back.devc.domain.post.comment.repository.CommentRepository;
+import com.back.devc.domain.post.comment.attachment.service.CommentAttachmentService;
+import com.back.devc.domain.post.post.entity.Post;
+import com.back.devc.domain.post.post.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CommentAttachmentService commentAttachmentService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    @DisplayName("댓글을 작성할 수 있다")
+    void createComment_success() {
+        // given
+        Long loginUserId = 2L;
+        Long postId = 10L;
+        CommentCreateRequest requestDto = new CommentCreateRequest("첫 댓글입니다.");
+
+        Post post = mock(Post.class);
+        Member member = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getTitle()).thenReturn("테스트 게시글");
+        when(memberRepository.findById(loginUserId)).thenReturn(Optional.of(member));
+        when(member.getUserId()).thenReturn(loginUserId);
+        when(member.getNickname()).thenReturn("작성자B");
+        when(commentAttachmentService.getAttachments(1L)).thenReturn(new CommentAttachmentListResponse(List.of()));
+
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 1L);
+            return saved;
+        });
+
+        // when
+        CommentResponse response = commentService.createComment(postId, loginUserId, requestDto);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.commentId()).isEqualTo(1L);
+        assertThat(response.postId()).isEqualTo(postId);
+        assertThat(response.userId()).isEqualTo(loginUserId);
+        assertThat(response.parentCommentId()).isNull();
+        assertThat(response.content()).isEqualTo("첫 댓글입니다.");
+        verify(notificationService).createCommentNotification(postId, loginUserId, 1L);
+    }
+
+    @Test
+    @DisplayName("내 게시글에 내가 댓글을 작성해도 서비스는 댓글 저장 후 알림 생성 메서드를 호출한다")
+    void createComment_callsNotificationMethod_evenWhenSelfComment() {
+        // given
+        Long loginUserId = 2L;
+        Long postId = 10L;
+        CommentCreateRequest requestDto = new CommentCreateRequest("내 글의 댓글입니다.");
+
+        Post post = mock(Post.class);
+        Member member = mock(Member.class);
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getTitle()).thenReturn("내 게시글");
+        when(memberRepository.findById(loginUserId)).thenReturn(Optional.of(member));
+        when(member.getUserId()).thenReturn(loginUserId);
+        when(member.getNickname()).thenReturn("작성자A");
+        when(commentAttachmentService.getAttachments(2L)).thenReturn(new CommentAttachmentListResponse(List.of()));
+
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 2L);
+            return saved;
+        });
+
+        // when
+        CommentResponse response = commentService.createComment(postId, loginUserId, requestDto);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.commentId()).isEqualTo(2L);
+        verify(notificationService).createCommentNotification(postId, loginUserId, 2L);
+    }
+
+    @Test
+    @DisplayName("대댓글을 작성할 수 있다")
+    void createReply_success() {
+        // given
+        Long loginUserId = 2L;
+        Long parentCommentId = 100L;
+        Long postId = 10L;
+        CommentCreateRequest requestDto = new CommentCreateRequest("대댓글입니다.");
+
+        Comment parentComment = new Comment(postId, 1L, null, "부모 댓글");
+        ReflectionTestUtils.setField(parentComment, "id", parentCommentId);
+
+        Post post = mock(Post.class);
+        Member member = mock(Member.class);
+
+        when(commentRepository.findById(parentCommentId)).thenReturn(Optional.of(parentComment));
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getTitle()).thenReturn("테스트 게시글");
+        when(memberRepository.findById(loginUserId)).thenReturn(Optional.of(member));
+        when(member.getUserId()).thenReturn(loginUserId);
+        when(member.getNickname()).thenReturn("작성자B");
+        when(commentAttachmentService.getAttachments(200L)).thenReturn(new CommentAttachmentListResponse(List.of()));
+
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 200L);
+            return saved;
+        });
+
+        // when
+        CommentResponse response = commentService.createReply(parentCommentId, loginUserId, requestDto);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.commentId()).isEqualTo(200L);
+        assertThat(response.parentCommentId()).isEqualTo(parentCommentId);
+        assertThat(response.content()).isEqualTo("대댓글입니다.");
+        verify(notificationService).createReplyNotification(parentCommentId, loginUserId, 200L);
+    }
+
+    @Test
+    @DisplayName("삭제된 댓글에는 답글을 작성할 수 없다")
+    void createReply_fail_whenParentDeleted() {
+        // given
+        Long parentCommentId = 100L;
+        Comment deletedParentComment = new Comment(10L, 1L, null, "삭제 전 댓글");
+        deletedParentComment.softDelete();
+
+        when(commentRepository.findById(parentCommentId)).thenReturn(Optional.of(deletedParentComment));
+
+        // when & then
+        assertThrows(IllegalArgumentException.class,
+                () -> commentService.createReply(parentCommentId, 2L, new CommentCreateRequest("대댓글")));
+        verify(notificationService, never()).createReplyNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("댓글을 수정할 수 있다")
+    void updateComment_success() {
+        // given
+        Long commentId = 1L;
+        Long loginUserId = 2L;
+        Long postId = 10L;
+        CommentUpdateRequest requestDto = new CommentUpdateRequest("수정된 댓글");
+
+        Comment comment = new Comment(postId, loginUserId, null, "기존 댓글");
+        ReflectionTestUtils.setField(comment, "id", commentId);
+
+        Post post = mock(Post.class);
+        Member member = mock(Member.class);
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getTitle()).thenReturn("테스트 게시글");
+        when(memberRepository.findById(loginUserId)).thenReturn(Optional.of(member));
+        when(member.getNickname()).thenReturn("작성자B");
+        when(commentAttachmentService.getAttachments(commentId)).thenReturn(new CommentAttachmentListResponse(List.of()));
+
+        // when
+        CommentResponse response = commentService.updateComment(commentId, loginUserId, requestDto);
+
+        // then
+        assertThat(comment.getContent()).isEqualTo("수정된 댓글");
+        assertThat(response.content()).isEqualTo("수정된 댓글");
+        assertThat(response.commentId()).isEqualTo(commentId);
+    }
+
+    @Test
+    @DisplayName("댓글을 삭제할 수 있다")
+    void deleteComment_success() {
+        // given
+        Long commentId = 1L;
+        Long loginUserId = 2L;
+
+        Comment comment = new Comment(10L, loginUserId, null, "삭제할 댓글");
+        ReflectionTestUtils.setField(comment, "id", commentId);
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+        // when
+        CommentDeleteResponse response = commentService.deleteComment(commentId, loginUserId);
+
+        // then
+        assertThat(comment.isDeleted()).isTrue();
+        assertThat(comment.getContent()).isEqualTo("삭제된 댓글입니다.");
+        assertThat(response.commentId()).isEqualTo(commentId);
+        assertThat(response.message()).isEqualTo("댓글 삭제 성공");
+    }
+
+    @Test
+    @DisplayName("게시글의 댓글 목록을 조회할 수 있다")
+    void getComments_success() {
+        // given
+        Long postId = 10L;
+        Post post = mock(Post.class);
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(post.getTitle()).thenReturn("테스트 게시글");
+
+        Comment parent = new Comment(postId, 1L, null, "부모 댓글");
+        ReflectionTestUtils.setField(parent, "id", 1L);
+
+        Comment reply = new Comment(postId, 2L, 1L, "대댓글");
+        ReflectionTestUtils.setField(reply, "id", 2L);
+
+        Member parentWriter = mock(Member.class);
+        Member replyWriter = mock(Member.class);
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(parentWriter));
+        when(memberRepository.findById(2L)).thenReturn(Optional.of(replyWriter));
+        when(parentWriter.getNickname()).thenReturn("작성자A");
+        when(replyWriter.getNickname()).thenReturn("작성자B");
+
+        when(commentRepository.findByPostIdOrderByCreatedAtAsc(postId)).thenReturn(List.of(parent, reply));
+        when(commentAttachmentService.getAttachments(1L)).thenReturn(new CommentAttachmentListResponse(List.of()));
+        when(commentAttachmentService.getAttachments(2L)).thenReturn(new CommentAttachmentListResponse(List.of()));
+
+        // when
+        CommentListResponse response = commentService.getComments(postId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.comments()).hasSize(1);
+        assertThat(response.comments().get(0).commentId()).isEqualTo(1L);
+        assertThat(response.comments().get(0).replies()).hasSize(1);
+        assertThat(response.comments().get(0).replies().get(0).commentId()).isEqualTo(2L);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #195 

## 🛠️ 작업 내용
- 댓글/알림/댓글 첨부파일 success code를 전용 enum으로 분리

- `SuccessResponse`에 `SuccessCodeSpec` 기반 공통 처리 구조 추가

- `CommentController`, `NotificationController`, `CommentAttachmentController`에서 전용 success code 사용하도록 수정

- `SuccessCode.java`에서 댓글/알림/첨부파일 관련 중복 success code 제거

- 댓글/알림/첨부파일 관련 테스트 코드 정리

## 🎯 리뷰 포인트
- 댓글/알림 파트 success code 분리 구조가 일관되게 적용되었는지

- 기존 `SuccessResponse` 호환 구조가 다른 도메인에 영향 없이 유지되는지

- 컨트롤러 테스트에서 응답 `code`, `message` 검증이 올바르게 반영되었는지

- 서비스 테스트가 현재 서비스 로직과 맞게 정리되었는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?