### PR TITLE
refactor: 댓글 알림 예외 코드 분리 및 에러 응답 구조 정리

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
@@ -8,7 +8,8 @@ import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.domain.post.comment.entity.Comment;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
 import com.back.devc.domain.post.post.repository.PostRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.back.devc.global.exception.ApiException;
+import com.back.devc.global.exception.errorCode.NotificationErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -301,10 +302,10 @@ public class NotificationService {
     @Transactional
     public NotificationResponse readNotification(Long notificationId, Long loginUserId) {
         Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new EntityNotFoundException("알림을 찾을 수 없습니다. id=" + notificationId));
+                .orElseThrow(() -> new ApiException(NotificationErrorCode.NOTIFICATION_404_NOT_FOUND));
 
         if (!notification.getUserId().equals(loginUserId)) {
-            throw new IllegalArgumentException("본인의 알림만 읽음 처리할 수 있습니다.");
+            throw new ApiException(NotificationErrorCode.NOTIFICATION_403_FORBIDDEN);
         }
 
         notification.markAsRead();
@@ -314,7 +315,7 @@ public class NotificationService {
     // 게시글 작성자를 조회해 알림 수신자(receiver)를 구하는 공통 메서드
     private Long findPostOwnerId(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId))
+                .orElseThrow(() -> new ApiException(NotificationErrorCode.NOTIFICATION_404_POST_NOT_FOUND))
                 .getMember()
                 .getUserId();
     }
@@ -322,14 +323,14 @@ public class NotificationService {
     // 댓글 작성자를 조회해 신고 알림 수신자(receiver)를 구하는 공통 메서드
     private Long findCommentOwnerId(Long commentId) {
         return commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId))
+                .orElseThrow(() -> new ApiException(NotificationErrorCode.NOTIFICATION_404_COMMENT_NOT_FOUND))
                 .getUserId();
     }
 
     // 댓글 조회 공통 메서드. 답글 알림 생성 시 부모 댓글 검증에 사용
     private Comment findCommentOrThrow(Long commentId, String message) {
         return commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException(message));
+                .orElseThrow(() -> new ApiException(NotificationErrorCode.NOTIFICATION_404_PARENT_COMMENT_NOT_FOUND));
     }
 
     /**
@@ -361,7 +362,7 @@ public class NotificationService {
     // actorUserId로 회원 닉네임을 조회하는 공통 메서드
     private String findMemberNickname(Long userId) {
         return memberRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. id=" + userId))
+                .orElseThrow(() -> new ApiException(NotificationErrorCode.NOTIFICATION_404_MEMBER_NOT_FOUND))
                 .getNickname();
     }
 

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/attachment/service/CommentAttachmentService.java
@@ -6,7 +6,8 @@ import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentRespons
 import com.back.devc.domain.post.comment.attachment.entity.CommentAttachment;
 import com.back.devc.domain.post.comment.attachment.repository.CommentAttachmentRepository;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.back.devc.global.exception.ApiException;
+import com.back.devc.global.exception.errorCode.CommentAttachmentErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +38,7 @@ public class CommentAttachmentService {
             List<Integer> fileOrders
     ) {
         commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
+                .orElseThrow(() -> new ApiException(CommentAttachmentErrorCode.COMMENT_ATTACHMENT_404_COMMENT_NOT_FOUND));
 
         if (files == null || files.isEmpty()) {
             return new CommentAttachmentListResponse(List.of());
@@ -109,7 +110,7 @@ public class CommentAttachmentService {
             Path targetPath = COMMENT_UPLOAD_DIR.resolve(storedName);
             Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            throw new UncheckedIOException("댓글 첨부파일 저장에 실패했습니다.", e);
+            throw new ApiException(CommentAttachmentErrorCode.COMMENT_ATTACHMENT_500_SAVE_FAILED);
         }
     }
 
@@ -118,13 +119,13 @@ public class CommentAttachmentService {
             Path targetPath = COMMENT_UPLOAD_DIR.resolve(storedName);
             Files.deleteIfExists(targetPath);
         } catch (IOException e) {
-            throw new UncheckedIOException("댓글 첨부파일 삭제에 실패했습니다.", e);
+            throw new ApiException(CommentAttachmentErrorCode.COMMENT_ATTACHMENT_500_DELETE_FAILED);
         }
     }
 
     public CommentAttachmentListResponse getAttachments(Long commentId) {
         commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
+                .orElseThrow(() -> new ApiException(CommentAttachmentErrorCode.COMMENT_ATTACHMENT_404_COMMENT_NOT_FOUND));
 
         List<CommentAttachmentResponse> responses = commentAttachmentRepository.findByCommentIdOrderByFileOrderAscIdAsc(commentId)
                 .stream()
@@ -148,10 +149,10 @@ public class CommentAttachmentService {
     @Transactional
     public CommentAttachmentDeleteResponse deleteAttachment(Long commentId, Long attachmentId) {
         commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
+                .orElseThrow(() -> new ApiException(CommentAttachmentErrorCode.COMMENT_ATTACHMENT_404_COMMENT_NOT_FOUND));
 
         CommentAttachment attachment = commentAttachmentRepository.findByIdAndCommentId(attachmentId, commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글 첨부파일을 찾을 수 없습니다. id=" + attachmentId));
+                .orElseThrow(() -> new ApiException(CommentAttachmentErrorCode.COMMENT_ATTACHMENT_404_NOT_FOUND));
 
         deleteFileIfExists(attachment.getStoredName());
         commentAttachmentRepository.delete(attachment);

--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentService.java
@@ -12,6 +12,8 @@ import com.back.devc.domain.member.member.entity.Member;
 import com.back.devc.domain.member.member.repository.MemberRepository;
 import com.back.devc.domain.post.post.entity.Post;
 import com.back.devc.domain.post.post.repository.PostRepository;
+import com.back.devc.global.exception.ApiException;
+import com.back.devc.global.exception.errorCode.CommentErrorCode;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,10 +39,10 @@ public class CommentService {
     @Transactional
     public CommentResponse createComment(Long postId, Long loginUserId, CommentCreateRequest request) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId));
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND));
 
         Member member = memberRepository.findById(loginUserId)
-                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. id=" + loginUserId));
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND));
 
         Comment comment = Comment.create(
                 postId,
@@ -56,17 +58,17 @@ public class CommentService {
     @Transactional
     public CommentResponse createReply(Long parentCommentId, Long loginUserId, CommentCreateRequest request) {
         Comment parentComment = commentRepository.findById(parentCommentId)
-                .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다. id=" + parentCommentId));
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_PARENT_NOT_FOUND));
 
         if (parentComment.isDeleted()) {
-            throw new IllegalArgumentException("삭제된 댓글에는 답글을 작성할 수 없습니다.");
+            throw new ApiException(CommentErrorCode.COMMENT_400_REPLY_TO_DELETED_COMMENT);
         }
 
         Post post = postRepository.findById(parentComment.getPostId())
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + parentComment.getPostId()));
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND));
 
         Member member = memberRepository.findById(loginUserId)
-                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. id=" + loginUserId));
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND));
 
         Comment reply = Comment.create(
                 parentComment.getPostId(),
@@ -161,24 +163,24 @@ public class CommentService {
 
     private Comment findComment(Long commentId) {
         return commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_NOT_FOUND));
     }
 
     private void validateOwner(Comment comment, Long loginUserId) {
         if (!comment.getUserId().equals(loginUserId)) {
-            throw new IllegalArgumentException("본인이 작성한 댓글만 수정/삭제할 수 있습니다.");
+            throw new ApiException(CommentErrorCode.COMMENT_403_FORBIDDEN);
         }
     }
 
     private String findPostTitle(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다. id=" + postId))
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND))
                 .getTitle();
     }
 
     private String findMemberNickname(Long userId) {
         return memberRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. id=" + userId))
+                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND))
                 .getNickname();
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ApiException.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ApiException.java
@@ -2,14 +2,19 @@ package com.back.devc.global.exception;
 
 public class ApiException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final ErrorCodeSpec errorCode;
 
     public ApiException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 
-    public ErrorCode getErrorCode() {
+    public ApiException(ErrorCodeSpec errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCodeSpec getErrorCode() {
         return errorCode;
     }
 }

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCode.java
@@ -2,7 +2,7 @@ package com.back.devc.global.exception;
 
 import org.springframework.http.HttpStatus;
 
-public enum ErrorCode {
+public enum ErrorCode implements ErrorCodeSpec {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
     ALREADY_DELETED(HttpStatus.GONE, "COMMON_410", "이미 삭제된 리소스입니다."),

--- a/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCodeSpec.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/ErrorCodeSpec.java
@@ -1,0 +1,16 @@
+package com.back.devc.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 도메인별로 분리된 에러 코드 enum 을 공통 방식으로 처리하기 위한 인터페이스.
+ *
+ * status  : HTTP 상태 코드
+ * code    : 에러 코드 식별자
+ * message : 에러 메시지
+ */
+public interface ErrorCodeSpec {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/back/DevC/src/main/java/com/back/devc/global/exception/GlobalExceptionHandler.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/GlobalExceptionHandler.java
@@ -17,7 +17,7 @@ public class GlobalExceptionHandler {
     // 비즈니스 예외 처리 (예: 이메일/닉네임 중복)
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handleApiException(ApiException e) {
-        ErrorCode errorCode = e.getErrorCode();
+        ErrorCodeSpec errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));

--- a/back/DevC/src/main/java/com/back/devc/global/exception/errorCode/CommentAttachmentErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/errorCode/CommentAttachmentErrorCode.java
@@ -1,0 +1,50 @@
+package com.back.devc.global.exception.errorCode;
+
+import com.back.devc.global.exception.ErrorCodeSpec;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * CommentAttachmentService / Controller 기준 실제 로직에서 필요한 댓글 첨부파일 관련 에러 코드.
+ *
+ * 현재 확인한 실제 예외 케이스
+ * - 댓글이 존재하지 않음
+ * - 삭제 대상 첨부파일이 존재하지 않음
+ * - 파일 저장 실패
+ * - 파일 삭제 실패
+ *
+ * 현재 로직에는 아래 항목이 없음
+ * - 첨부파일 권한 체크
+ * - fileOrder 유효성 검증
+ * - 빈 파일 업로드 예외 (빈 리스트는 정상적으로 빈 응답 반환)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CommentAttachmentErrorCode implements ErrorCodeSpec {
+
+    COMMENT_ATTACHMENT_404_COMMENT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "COMMENT_ATTACHMENT_404_COMMENT_NOT_FOUND",
+            "댓글을 찾을 수 없습니다."
+    ),
+    COMMENT_ATTACHMENT_404_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "COMMENT_ATTACHMENT_404_NOT_FOUND",
+            "댓글 첨부파일을 찾을 수 없습니다."
+    ),
+    COMMENT_ATTACHMENT_500_SAVE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "COMMENT_ATTACHMENT_500_SAVE_FAILED",
+            "댓글 첨부파일 저장에 실패했습니다."
+    ),
+    COMMENT_ATTACHMENT_500_DELETE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "COMMENT_ATTACHMENT_500_DELETE_FAILED",
+            "댓글 첨부파일 삭제에 실패했습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/back/DevC/src/main/java/com/back/devc/global/exception/errorCode/CommentErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/errorCode/CommentErrorCode.java
@@ -1,0 +1,58 @@
+package com.back.devc.global.exception.errorCode;
+
+import com.back.devc.global.exception.ErrorCodeSpec;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * CommentService 기준 실제 로직에서 필요한 댓글 관련 에러 코드.
+ *
+ * 현재 확인한 실제 예외 케이스
+ * - 댓글이 존재하지 않음
+ * - 부모 댓글이 존재하지 않음
+ * - 게시글이 존재하지 않음
+ * - 회원이 존재하지 않음
+ * - 삭제된 댓글에는 답글 작성 불가
+ * - 본인이 작성한 댓글만 수정/삭제 가능
+ *
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode implements ErrorCodeSpec {
+
+    COMMENT_404_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "COMMENT_404_NOT_FOUND",
+            "댓글을 찾을 수 없습니다."
+    ),
+    COMMENT_404_PARENT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "COMMENT_404_PARENT_NOT_FOUND",
+            "부모 댓글을 찾을 수 없습니다."
+    ),
+    COMMENT_404_POST_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "COMMENT_404_POST_NOT_FOUND",
+            "게시글을 찾을 수 없습니다."
+    ),
+    COMMENT_404_MEMBER_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "COMMENT_404_MEMBER_NOT_FOUND",
+            "회원을 찾을 수 없습니다."
+    ),
+    COMMENT_400_REPLY_TO_DELETED_COMMENT(
+            HttpStatus.BAD_REQUEST,
+            "COMMENT_400_REPLY_TO_DELETED_COMMENT",
+            "삭제된 댓글에는 답글을 작성할 수 없습니다."
+    ),
+    COMMENT_403_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "COMMENT_403_FORBIDDEN",
+            "본인이 작성한 댓글만 수정/삭제할 수 있습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/back/DevC/src/main/java/com/back/devc/global/exception/errorCode/NotificationErrorCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/exception/errorCode/NotificationErrorCode.java
@@ -1,0 +1,57 @@
+package com.back.devc.global.exception.errorCode;
+
+import com.back.devc.global.exception.ErrorCodeSpec;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * NotificationService 기준 실제 로직에서 필요한 알림 관련 에러 코드.
+ *
+ * 현재 확인한 실제 예외 케이스
+ * - 알림이 존재하지 않음
+ * - 본인 알림이 아닌 경우 읽음 처리 불가
+ * - 게시글이 존재하지 않음
+ * - 댓글이 존재하지 않음
+ * - 부모 댓글이 존재하지 않음
+ * - 회원이 존재하지 않음
+ */
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCodeSpec {
+
+    NOTIFICATION_404_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "NOTIFICATION_404_NOT_FOUND",
+            "알림을 찾을 수 없습니다."
+    ),
+    NOTIFICATION_403_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "NOTIFICATION_403_FORBIDDEN",
+            "본인의 알림만 읽음 처리할 수 있습니다."
+    ),
+    NOTIFICATION_404_POST_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "NOTIFICATION_404_POST_NOT_FOUND",
+            "게시글을 찾을 수 없습니다."
+    ),
+    NOTIFICATION_404_COMMENT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "NOTIFICATION_404_COMMENT_NOT_FOUND",
+            "댓글을 찾을 수 없습니다."
+    ),
+    NOTIFICATION_404_PARENT_COMMENT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "NOTIFICATION_404_PARENT_COMMENT_NOT_FOUND",
+            "부모 댓글을 찾을 수 없습니다."
+    ),
+    NOTIFICATION_404_MEMBER_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "NOTIFICATION_404_MEMBER_NOT_FOUND",
+            "회원을 찾을 수 없습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/back/DevC/src/main/java/com/back/devc/global/response/ErrorResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.back.devc.global.response;
 
 import com.back.devc.global.exception.ErrorCode;
+import com.back.devc.global.exception.ErrorCodeSpec;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -11,7 +12,17 @@ public record ErrorResponse(
         LocalDateTime timestamp,
         Map<String, String> validation
 ) {
+
     public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                Map.of()
+        );
+    }
+
+    public static ErrorResponse of(ErrorCodeSpec errorCode) {
         return new ErrorResponse(
                 errorCode.getCode(),
                 errorCode.getMessage(),
@@ -28,4 +39,5 @@ public record ErrorResponse(
                 validation
         );
     }
+
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #202 

## 🛠️ 작업 내용
- `ErrorCodeSpec` 인터페이스 추가

- `ErrorCode`가 `ErrorCodeSpec`을 구현하도록 수정

- `ApiException`이 `ErrorCodeSpec` 기반으로 동작하도록 수정

- `GlobalExceptionHandler`에서 `ErrorCodeSpec` 처리하도록 수정

- `ErrorResponse`에 `ErrorCodeSpec` 대응 메서드 추가

- `CommentAttachmentErrorCode`, `CommentErrorCode`, `NotificationErrorCode` 추가

- `CommentAttachmentService`, `CommentService`, `NotificationService` 예외를 도메인별 `ApiException`으로 변경

## 🎯 리뷰 포인트
- 성공코드 분리 방식과 동일한 기준으로 에러코드도 일관되게 분리되었는지

- `ApiException`, `GlobalExceptionHandler`, `ErrorResponse`가 기존 구조와 새 구조를 모두 수용하는지

- 댓글/알림/첨부파일 서비스에서 실제 로직 기준 예외가 적절한 도메인 에러코드로 치환되었는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?