### PR TITLE
refactor: DTO 빌더 제거 및 직접 생성 방식으로 통일(#205)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/dto/CommentResponse.java
@@ -1,13 +1,11 @@
 package com.back.devc.domain.post.comment.dto;
 
 import com.back.devc.domain.post.comment.attachment.dto.CommentAttachmentResponse;
-import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Builder
 public record CommentResponse(
         Long commentId,
         Long postId,
@@ -35,19 +33,19 @@ public record CommentResponse(
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return CommentResponse.builder()
-                .commentId(commentId)
-                .postId(postId)
-                .postTitle(postTitle)
-                .userId(userId)
-                .nickname(nickname)
-                .parentCommentId(parentCommentId)
-                .content(content)
-                .isDeleted(isDeleted)
-                .createdAt(createdAt)
-                .updatedAt(updatedAt)
-                .replies(new ArrayList<>())
-                .attachments(new ArrayList<>())
-                .build();
+        return new CommentResponse(
+                commentId,
+                postId,
+                postTitle,
+                userId,
+                nickname,
+                parentCommentId,
+                content,
+                isDeleted,
+                createdAt,
+                updatedAt,
+                new ArrayList<>(),
+                new ArrayList<>()
+        );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #205 

## 🛠️ 작업 내용
- DTO에서 `@Builder` 제거

- `lombok.Builder` import 제거

- static factory 메서드 내부를 builder 체인 방식에서 직접 생성 방식으로 변경

- DTO 생성 방식을 팀 컨벤션에 맞게 통일

## 🎯 리뷰 포인트
- DTO에 builder 사용이 남아 있지 않은지

- static factory 메서드가 `new DTO(...)` 방식으로 잘 변경되었는지

- record DTO 구조와 충돌 없이 동작하는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] DTO 빌더 제거

- [x] import 정리

- [x] static factory 방식 통일

- [ ] 전체 빌드/테스트 확인