### PR TITLE
[Refactor] SuccessCode에서 게시물 관련 성공 코드를 분리하여 PostSuccessCode로 변경

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/post/post/controller/PostController.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/post/controller/PostController.java
@@ -5,6 +5,7 @@ import com.back.devc.domain.post.post.entity.Post;
 import com.back.devc.domain.post.post.service.PostService;
 import com.back.devc.domain.post.post.type.PostSearchType;
 import com.back.devc.domain.post.post.type.PostSortType;
+import com.back.devc.global.response.successCode.PostSuccessCode;
 import com.back.devc.global.security.jwt.JwtPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class PostController {
 
         PostCreateResponse response = postService.write(userId, request);
 
-        SuccessCode successCode = SuccessCode.POST_CREATE_SUCCESS;
+        PostSuccessCode successCode = PostSuccessCode.POST_201_CREATE_SUCCESS;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -50,14 +51,13 @@ public class PostController {
         Long loginUserId = principal != null ? principal.userId() : null;
 
         PostDetailResponse response = postService.findDetailById(postid, loginUserId);
-        SuccessCode successCode = SuccessCode.POST_DETAIL_SUCCESS;
+        PostSuccessCode successCode = PostSuccessCode.POST_200_DETAIL_SUCCESS;
 
         return ResponseEntity
                 .status(successCode.getStatus())
                 .body(SuccessResponse.of(successCode, response));
 
     }
-
 
     //게시글 목록조회
     @GetMapping
@@ -82,7 +82,7 @@ public class PostController {
                 size
         );
 
-        SuccessCode successCode = SuccessCode.POST_LIST_SUCCESS;
+        PostSuccessCode successCode = PostSuccessCode.POST_200_LIST_SUCCESS;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -101,7 +101,7 @@ public class PostController {
 
         PostUpdateResponse response = postService.update(userId, postId, request);
 
-        SuccessCode successCode = SuccessCode.POST_UPDATE_SUCCESS;
+        PostSuccessCode successCode = PostSuccessCode.POST_200_UPDATE_SUCCESS;
 
         return ResponseEntity
                 .status(successCode.getStatus())
@@ -118,7 +118,7 @@ public class PostController {
 
         PostDeleteResponse response = postService.delete(userId, postId);
 
-        SuccessCode successCode = SuccessCode.POST_DELETE_SUCCESS;
+        PostSuccessCode successCode = PostSuccessCode.POST_200_DELETE_SUCCESS;
 
         return ResponseEntity
                 .status(successCode.getStatus())

--- a/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/SuccessCode.java
@@ -22,13 +22,6 @@ public enum SuccessCode {
     REPORT_COMMENT_SUCCESS(HttpStatus.CREATED, "REPORT_201_COMMENT", "댓글 신고가 정상적으로 접수되었습니다."),
 
 
-    POST_CREATE_SUCCESS(HttpStatus.CREATED,"POST_201_CREATE_SUCCESS", "게시글 작성 성공"),
-    POST_LIST_SUCCESS(HttpStatus.OK,"POST_200_LIST_SUCCESS", "게시글 목록 조회 성공"),
-    POST_DETAIL_SUCCESS(HttpStatus.OK,"POST_200_DETAIL_SUCCESS", "게시글 상세 조회 성공"),
-    POST_UPDATE_SUCCESS(HttpStatus.OK,"POST_200_UPDATE_SUCCESS", "게시글 수정 성공"),
-    POST_DELETE_SUCCESS(HttpStatus.OK,"POST_200_DELETE_SUCCESS", "게시글 삭제 성공"),
-
-
     // 대시보드 관련 성공 코드
     DASHBOARD_LIST(HttpStatus.OK, "DASHBOARD_200_LIST", "대시보드 조회 성공"),
 

--- a/back/DevC/src/main/java/com/back/devc/global/response/successCode/PostSuccessCode.java
+++ b/back/DevC/src/main/java/com/back/devc/global/response/successCode/PostSuccessCode.java
@@ -1,0 +1,21 @@
+package com.back.devc.global.response.successCode;
+import com.back.devc.global.response.SuccessCodeSpec;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostSuccessCode implements SuccessCodeSpec {
+
+    POST_201_CREATE_SUCCESS(HttpStatus.CREATED,"POST_201_CREATE_SUCCESS", "게시글 작성 성공"),
+    POST_200_LIST_SUCCESS(HttpStatus.OK,"POST_200_LIST_SUCCESS", "게시글 목록 조회 성공"),
+    POST_200_DETAIL_SUCCESS(HttpStatus.OK,"POST_200_DETAIL_SUCCESS", "게시글 상세 조회 성공"),
+    POST_200_UPDATE_SUCCESS(HttpStatus.OK,"POST_200_UPDATE_SUCCESS", "게시글 수정 성공"),
+    POST_200_DELETE_SUCCESS(HttpStatus.OK,"POST_200_DELETE_SUCCESS", "게시글 삭제 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`
Closes #

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 기존 SuccessCode 내에 작성한 Post관련 SuceessCode를 따로 enum 파일을 만들어 리팩토링 하였습니다.
- [x] implements SuccessCodeSpec을 이용하였습니다.
- [x] POST_CREATE_SUCCESS 로 정의된 코드를 POST_201_CREATE_SUCCESS 와 같이 201 (에러코드) 를 추가하여 변경하였습니다.
- [x] 위의 부분을 수정하였기 때문에 PostController 부분에 업데이트된 성공 코드를 대입하였습니다. 



## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?