### PR TITLE
fix: 프론트 사이트명 DevC 통일 및 알림 표시 정리(#215)

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -105,7 +105,7 @@ export default function LoginPage() {
         <div className="mb-8 text-center">
           <Link href="/" className="inline-flex items-center gap-2">
             <Code2 className="h-8 w-8 text-primary" />
-            <span className="text-2xl font-bold text-foreground">DevHub</span>
+            <span className="text-2xl font-bold text-foreground">DevC</span>
           </Link>
           <p className="mt-2 text-muted-foreground">계정으로 로그인하세요</p>
         </div>

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -480,31 +480,19 @@ export default function NotificationsPage() {
                                         </div>
 
                                         <div className="min-w-0 flex-1">
-                                            <div className="flex items-start gap-2">
-                                                <Avatar className="h-6 w-6">
-                                                    <AvatarImage
-                                                        src={undefined}
-                                                        alt={notification.actorNickname ?? `${notification.actorUserId}번 사용자`}
-                                                    />
-                                                    <AvatarFallback
-                                                        className="bg-secondary text-xs text-secondary-foreground">
-                                                        {notification.actorNickname?.trim()?.slice(0, 2) || `U${notification.actorUserId}`}
-                                                    </AvatarFallback>
-                                                </Avatar>
-                                                <div className="flex-1">
-                                                    <p className="text-sm text-foreground">{notification.message}</p>
-                                                    {notification.postId ? (
-                                                        <Link
-                                                            href={`/posts/${notification.postId}`}
-                                                            className="mt-1 line-clamp-1 text-sm text-primary hover:underline"
-                                                        >
-                                                            게시글로 이동
-                                                        </Link>
-                                                    ) : null}
-                                                    <p className="mt-1 text-xs text-muted-foreground">
-                                                        {formatRelativeDate(notification.createdAt)}
-                                                    </p>
-                                                </div>
+                                            <div className="flex-1">
+                                                <p className="text-sm text-foreground">{notification.message}</p>
+                                                {notification.postId ? (
+                                                    <Link
+                                                        href={`/posts/${notification.postId}`}
+                                                        className="mt-1 line-clamp-1 text-sm text-primary hover:underline"
+                                                    >
+                                                        게시글로 이동
+                                                    </Link>
+                                                ) : null}
+                                                <p className="mt-1 text-xs text-muted-foreground">
+                                                    {formatRelativeDate(notification.createdAt)}
+                                                </p>
                                             </div>
                                         </div>
 

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -100,7 +100,7 @@ export default function SignUpPage() {
         <div className="mb-8 text-center">
           <Link href="/" className="inline-flex items-center gap-2">
             <Code2 className="h-8 w-8 text-primary" />
-            <span className="text-2xl font-bold text-foreground">DevHub</span>
+            <span className="text-2xl font-bold text-foreground">DevC</span>
           </Link>
           <p className="mt-2 text-muted-foreground">새 계정을 만들어 시작하세요</p>
         </div>

--- a/frontend/components/layout/footer.tsx
+++ b/frontend/components/layout/footer.tsx
@@ -39,7 +39,7 @@ export function Footer() {
           <div className="md:col-span-2">
             <Link href="/" className="flex items-center gap-2">
               <Code2 className="h-6 w-6 text-primary" />
-              <span className="text-lg font-bold text-foreground">DevConnect</span>
+              <span className="text-lg font-bold text-foreground">DevC</span>
             </Link>
             <p className="mt-4 max-w-md text-sm leading-relaxed text-muted-foreground">
               개발자들을 위한 지식 공유 커뮤니티입니다. 최신 기술 트렌드, 실무 경험, 다양한 개발 이야기를 함께 나눠보세요.
@@ -130,7 +130,7 @@ export function Footer() {
 
         <div className="mt-12 border-t border-border pt-8">
           <p className="text-center text-sm text-muted-foreground">
-            &copy; {new Date().getFullYear()} DevHub. All rights reserved.
+            &copy; {new Date().getFullYear()} DevC. All rights reserved.
           </p>
         </div>
       </div>

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -205,7 +205,7 @@ export function Header() {
             <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
                 <Link href="/" className="flex items-center gap-2">
                     <Code2 className="h-7 w-7 text-primary"/>
-                    <span className="text-xl font-bold text-foreground">DevConnect</span>
+                    <span className="text-xl font-bold text-foreground">DevC</span>
                 </Link>
 
                 <nav className="hidden items-center gap-6 md:flex">


### PR DESCRIPTION
## 📌 관련 이슈

Closes #215 

## 🛠️ 작업 내용
- 프론트 화면 내 사이트명 표기를 `DevC`로 통일

- 알림 페이지에서 메시지 옆 이니셜 아바타 제거

- 알림 아이템 레이아웃 단순화 및 가독성 개선

## 🎯 리뷰 포인트
- 사이트명 표기가 모든 관련 화면에서 `DevC`로 일관되게 적용되었는지

- 알림 목록에서 이니셜 아바타가 제거되고 레이아웃이 자연스럽게 유지되는지

- 기존 알림 기능(게시글 이동, 읽음 처리 등)에 영향이 없는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?