### PR TITLE
fix: 신고 처리 알림 재전송 및 신고 알림 아이콘 개선(#217)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/interaction/notification/service/NotificationService.java
@@ -188,24 +188,13 @@ public class NotificationService {
      * 주의 사항
      * - 관리자 처리 후에만 신고 대상 게시글 작성자에게 REPORT 알림을 생성한다.
      * - 알림 메시지에는 신고한 사용자를 노출하지 않는다.
-     * - 같은 게시글에 대해 REPORT 알림이 여러 번 쌓이지 않도록 중복 생성 방지 검사를 수행한다.
+     * - 관리자 처리 완료 시점마다 대상 게시글 작성자에게 REPORT 알림을 생성한다.
      */
     @Transactional
     public void createPostReportNotification(Long postId, Long adminUserId) {
         Long postOwnerId = findPostOwnerId(postId);
 
         if (postOwnerId.equals(adminUserId)) {
-            return;
-        }
-
-        boolean alreadyNotified = notificationRepository.findByUserIdOrderByCreatedAtDesc(postOwnerId)
-                .stream()
-                .anyMatch(notification ->
-                        "REPORT".equals(notification.getType())
-                                && postId.equals(notification.getPostId())
-                );
-
-        if (alreadyNotified) {
             return;
         }
 
@@ -225,24 +214,13 @@ public class NotificationService {
      * 주의 사항
      * - 관리자 처리 후에만 신고 대상 댓글 작성자에게 REPORT 알림을 생성한다.
      * - 알림 메시지에는 신고한 사용자를 노출하지 않는다.
-     * - 같은 댓글에 대해 REPORT 알림이 여러 번 쌓이지 않도록 중복 생성 방지 검사를 수행한다.
+     * - 관리자 처리 완료 시점마다 대상 댓글 작성자에게 REPORT 알림을 생성한다.
      */
     @Transactional
     public void createCommentReportNotification(Long commentId, Long adminUserId) {
         Long commentOwnerId = findCommentOwnerId(commentId);
 
         if (commentOwnerId.equals(adminUserId)) {
-            return;
-        }
-
-        boolean alreadyNotified = notificationRepository.findByUserIdOrderByCreatedAtDesc(commentOwnerId)
-                .stream()
-                .anyMatch(notification ->
-                        "REPORT".equals(notification.getType())
-                                && commentId.equals(notification.getCommentId())
-                );
-
-        if (alreadyNotified) {
             return;
         }
 

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -3,7 +3,7 @@
 import {useCallback, useEffect, useMemo, useState} from "react"
 import Link from "next/link"
 import {useRouter} from "next/navigation"
-import {Bell, MessageCircle, Heart, UserPlus, Check} from "lucide-react"
+import {Bell, MessageCircle, Heart, UserPlus, Check, TriangleAlert} from "lucide-react"
 import {Button} from "@/components/ui/button"
 import {Avatar, AvatarFallback, AvatarImage} from "@/components/ui/avatar"
 import {Tabs, TabsContent, TabsList, TabsTrigger} from "@/components/ui/tabs"
@@ -11,7 +11,7 @@ import {getAuthSnapshot} from "@/lib/auth-storage"
 
 const API_BASE_URL = "http://localhost:8080"
 
-type NotificationType = "comment" | "reply" | "like" | "follow"
+type NotificationType = "comment" | "reply" | "like" | "follow" | "report"
 
 type NotificationItem = {
     notificationId: number
@@ -107,7 +107,7 @@ function mapBackendType(type: string): NotificationType {
         case "BOOKMARK":
             return "like"
         case "REPORT":
-            return "comment"
+            return "report"
         default:
             return "comment"
     }
@@ -122,6 +122,8 @@ function getNotificationIcon(type: NotificationType) {
             return <Heart className="h-4 w-4"/>
         case "follow":
             return <UserPlus className="h-4 w-4"/>
+        case "report":
+            return <TriangleAlert className="h-4 w-4"/>
         default:
             return <Bell className="h-4 w-4"/>
     }
@@ -136,6 +138,8 @@ function getNotificationColor(type: NotificationType) {
             return "bg-red-500/20 text-red-400"
         case "follow":
             return "bg-green-500/20 text-green-400"
+        case "report":
+            return "bg-yellow-500/20 text-yellow-400"
         default:
             return "bg-primary/20 text-primary"
     }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #217 

## 🛠️ 작업 내용
- `NotificationService`에서 게시글/댓글 REPORT 알림 중복 차단 로직 제거

- 관리자 신고 처리 완료 시마다 REPORT 알림이 생성되도록 수정

- 알림 페이지에서 `REPORT` 타입을 별도 `report` 타입으로 매핑

- REPORT 알림 아이콘을 `TriangleAlert`로 변경

- REPORT 알림 색상을 경고 계열 색상으로 적용

## 🎯 리뷰 포인트
- 관리자 신고 처리 시 매번 REPORT 알림이 정상 생성되는지

- 기존 댓글/좋아요/북마크 알림 아이콘 및 색상에는 영향이 없는지

- REPORT 알림만 경고형 아이콘과 색상으로 잘 구분되는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="513" height="196" alt="image" src="https://github.com/user-attachments/assets/1fd286c9-138c-42dd-9bf7-a012e48e6fdd" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?