### PR TITLE
feat: 댓글 수 동기화 및 댓글 서비스 로깅 추가(#225)

### DIFF
--- a/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/comment/service/CommentService.java
@@ -14,9 +14,11 @@ import com.back.devc.domain.post.comment.entity.Comment;
 import com.back.devc.domain.post.comment.repository.CommentRepository;
 import com.back.devc.domain.post.post.entity.Post;
 import com.back.devc.domain.post.post.repository.PostRepository;
+import com.back.devc.domain.post.post.service.PostService;
 import com.back.devc.global.exception.ApiException;
 import com.back.devc.global.exception.errorCode.CommentErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -32,17 +35,25 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
+    private final PostService postService;
     private final MemberRepository memberRepository;
     private final CommentAttachmentService commentAttachmentService;
     private final NotificationService notificationService;
 
     @Transactional
     public CommentResponse createComment(Long postId, Long loginUserId, CommentCreateRequest request) {
+        log.info("댓글 작성 시작 - postId={}, loginUserId={}", postId, loginUserId);
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("댓글 작성 실패 - 게시글 없음, postId={}", postId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND);
+                });
 
         Member member = memberRepository.findById(loginUserId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("댓글 작성 실패 - 회원 없음, loginUserId={}", loginUserId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND);
+                });
 
         Comment comment = Comment.create(
                 postId,
@@ -51,25 +62,39 @@ public class CommentService {
                 request.content()
         );
         Comment savedComment = commentRepository.save(comment);
+        postService.increaseCommentCount(postId);
+        log.info("댓글 저장 완료 - commentId={}, postId={}, loginUserId={}", savedComment.getId(), postId, loginUserId);
         notificationService.createCommentNotification(postId, loginUserId, savedComment.getId());
+        log.info("댓글 알림 처리 요청 완료 - commentId={}, postId={}", savedComment.getId(), postId);
 
         return toResponse(savedComment, post.getTitle(), MemberDisplayUtil.getDisplayName(member));
     }
 
     @Transactional
     public CommentResponse createReply(Long parentCommentId, Long loginUserId, CommentCreateRequest request) {
+        log.info("대댓글 작성 시작 - parentCommentId={}, loginUserId={}", parentCommentId, loginUserId);
         Comment parentComment = commentRepository.findById(parentCommentId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_PARENT_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("대댓글 작성 실패 - 부모 댓글 없음, parentCommentId={}", parentCommentId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_PARENT_NOT_FOUND);
+                });
 
         if (parentComment.isDeleted()) {
+            log.warn("대댓글 작성 실패 - 삭제된 부모 댓글, parentCommentId={}", parentCommentId);
             throw new ApiException(CommentErrorCode.COMMENT_400_REPLY_TO_DELETED_COMMENT);
         }
 
         Post post = postRepository.findById(parentComment.getPostId())
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("대댓글 작성 실패 - 게시글 없음, postId={}", parentComment.getPostId());
+                    return new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND);
+                });
 
         Member member = memberRepository.findById(loginUserId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("대댓글 작성 실패 - 회원 없음, loginUserId={}", loginUserId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND);
+                });
 
         Comment reply = Comment.create(
                 parentComment.getPostId(),
@@ -78,17 +103,22 @@ public class CommentService {
                 request.content()
         );
         Comment savedReply = commentRepository.save(reply);
+        postService.increaseCommentCount(parentComment.getPostId());
+        log.info("대댓글 저장 완료 - replyCommentId={}, parentCommentId={}, loginUserId={}", savedReply.getId(), parentCommentId, loginUserId);
         notificationService.createReplyNotification(parentCommentId, loginUserId, savedReply.getId());
+        log.info("답글 알림 처리 요청 완료 - replyCommentId={}, parentCommentId={}", savedReply.getId(), parentCommentId);
 
         return toResponse(savedReply, post.getTitle(), MemberDisplayUtil.getDisplayName(member));
     }
 
     @Transactional
     public CommentResponse updateComment(Long commentId, Long loginUserId, CommentUpdateRequest request) {
+        log.info("댓글 수정 시작 - commentId={}, loginUserId={}", commentId, loginUserId);
         Comment comment = findComment(commentId);
         validateOwner(comment, loginUserId);
 
         comment.updateContent(request.content());
+        log.info("댓글 수정 완료 - commentId={}, loginUserId={}", commentId, loginUserId);
 
         String postTitle = findPostTitle(comment.getPostId());
         String nickname = findMemberNickname(comment.getUserId());
@@ -101,16 +131,25 @@ public class CommentService {
         Comment comment = findComment(commentId);
         validateOwner(comment, loginUserId);
 
-        comment.softDelete();
+        if (!comment.isDeleted()) {
+            comment.softDelete();
+            postService.decreaseCommentCount(comment.getPostId());
+            log.info("댓글 삭제 완료 - commentId={}, postId={}, loginUserId={}", commentId, comment.getPostId(), loginUserId);
+        }
 
         return new CommentDeleteResponse(commentId, "댓글 삭제 성공");
     }
 
     public CommentListResponse getComments(Long postId) {
+        log.info("댓글 목록 조회 시작 - postId={}", postId);
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("댓글 목록 조회 실패 - 게시글 없음, postId={}", postId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND);
+                });
 
         List<Comment> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId);
+        log.info("댓글 목록 조회 완료 - postId={}, count={}", postId, comments.size());
         List<CommentResponse> responses = comments.stream()
                 .map(comment -> toResponse(comment, post.getTitle(), findMemberNickname(comment.getUserId())))
                 .toList();
@@ -165,24 +204,34 @@ public class CommentService {
 
     private Comment findComment(Long commentId) {
         return commentRepository.findById(commentId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("댓글 조회 실패 - 댓글 없음, commentId={}", commentId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_NOT_FOUND);
+                });
     }
 
     private void validateOwner(Comment comment, Long loginUserId) {
         if (!comment.getUserId().equals(loginUserId)) {
+            log.warn("댓글 권한 검증 실패 - commentId={}, ownerUserId={}, loginUserId={}", comment.getId(), comment.getUserId(), loginUserId);
             throw new ApiException(CommentErrorCode.COMMENT_403_FORBIDDEN);
         }
     }
 
     private String findPostTitle(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND))
+                .orElseThrow(() -> {
+                    log.warn("게시글 제목 조회 실패 - 게시글 없음, postId={}", postId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_POST_NOT_FOUND);
+                })
                 .getTitle();
     }
 
     private String findMemberNickname(Long userId) {
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("회원 닉네임 조회 실패 - 회원 없음, userId={}", userId);
+                    return new ApiException(CommentErrorCode.COMMENT_404_MEMBER_NOT_FOUND);
+                });
 
         return MemberDisplayUtil.getDisplayName(member);
     }

--- a/back/DevC/src/main/java/com/back/devc/domain/post/post/service/PostService.java
+++ b/back/DevC/src/main/java/com/back/devc/domain/post/post/service/PostService.java
@@ -160,6 +160,14 @@ public class PostService {
         post.increaseCommentCount();
     }
 
+    @Transactional
+    public void decreaseCommentCount(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ApiException(PostErrorCode.POST_404_NOT_FOUND));
+
+        post.decreaseCommentCount();
+    }
+
     public PostUpdateResponse update(Long memberId, Long postId, PostUpdateRequest request) {
 
         Post post = postRepository.findById(postId)

--- a/back/DevC/src/main/resources/application.yaml
+++ b/back/DevC/src/main/resources/application.yaml
@@ -25,16 +25,18 @@ spring:
         use_sql_comments: true
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
 
 springdoc:
   default-produces-media-type: application/json; charset=UTF-8
 
 logging:
   level:
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.hibernate.orm.jdbc.extract: TRACE
-    org.springframework.transaction.interceptor: TRACE
+    org.hibernate.orm.jdbc.bind: WARN
+    org.hibernate.orm.jdbc.extract: WARN
+    org.springframework.transaction.interceptor: WARN
+    org.hibernate.SQL: WARN
+    com.zaxxer.hikari: WARN
     com.back: INFO
 
 custom:

--- a/back/DevC/src/main/resources/logback-spring.xml
+++ b/back/DevC/src/main/resources/logback-spring.xml
@@ -10,7 +10,7 @@
     <!-- ========================= -->
     <springProfile name="dev">
 
-        <property name="LOG_LEVEL" value="DEBUG"/>
+        <property name="LOG_LEVEL" value="INFO"/>
 
         <property name="CONSOLE_PATTERN"
                   value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta(%-4relative) --- [ %thread{10} ] %cyan(%logger{30}) : %msg%n"/>
@@ -38,10 +38,12 @@
             </rollingPolicy>
         </appender>
 
-        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="DEBUG"/>
-        <logger name="org.springframework" level="INFO"/>
-        <logger name="org.hibernate" level="INFO"/>
-        <logger name="org.h2.server.web" level="INFO"/>
+        <logger name="com.back.devc" level="INFO"/>
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="WARN"/>
+        <logger name="org.springframework" level="WARN"/>
+        <logger name="org.hibernate" level="WARN"/>
+        <logger name="org.h2.server.web" level="WARN"/>
+        <logger name="com.zaxxer.hikari" level="WARN"/>
 
         <root level="${LOG_LEVEL}">
             <appender-ref ref="CONSOLE"/>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -242,9 +242,24 @@ export default function HomePage() {
       void loadPosts()
     }
 
+    const handleWindowFocus = () => {
+      void loadPosts()
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void loadPosts()
+      }
+    }
+
     window.addEventListener(AUTH_CHANGED_EVENT, handleAuthChanged)
+    window.addEventListener("focus", handleWindowFocus)
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
     return () => {
       window.removeEventListener(AUTH_CHANGED_EVENT, handleAuthChanged)
+      window.removeEventListener("focus", handleWindowFocus)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
     }
   }, [loadPosts])
 

--- a/frontend/app/posts/[postId]/page.tsx
+++ b/frontend/app/posts/[postId]/page.tsx
@@ -227,38 +227,38 @@ export default function PostDetailPage() {
     }
   }, [loginPath])
 
-  useEffect(() => {
-    const loadPost = async () => {
-      if (!postId || Number.isNaN(postId)) {
-        setLoading(false)
-        return
-      }
-
-      try {
-        setLoading(true)
-        setError(null)
-
-        const response = await fetch(`${API_BASE_URL}/api/posts/${postId}`, {
-          credentials: "include",
-          headers: getAuthHeaders(),
-          cache: "no-store",
-        })
-
-        if (!response.ok) {
-          throw new Error("게시글을 불러오지 못했습니다.")
-        }
-
-        const res = await response.json()
-        setPost(res.data)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
-      } finally {
-        setLoading(false)
-      }
+  const loadPost = useCallback(async () => {
+    if (!postId || Number.isNaN(postId)) {
+      setLoading(false)
+      return
     }
 
-    void loadPost()
+    try {
+      setLoading(true)
+      setError(null)
+
+      const response = await fetch(`${API_BASE_URL}/api/posts/${postId}`, {
+        credentials: "include",
+        headers: getAuthHeaders(),
+        cache: "no-store",
+      })
+
+      if (!response.ok) {
+        throw new Error("게시글을 불러오지 못했습니다.")
+      }
+
+      const res = await response.json()
+      setPost(res.data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
+    } finally {
+      setLoading(false)
+    }
   }, [postId])
+
+  useEffect(() => {
+    void loadPost()
+  }, [loadPost])
 
   useEffect(() => {
     const loadMe = async () => {
@@ -469,7 +469,7 @@ export default function PostDetailPage() {
         )}
       </section>
 
-      <CommentSection postId={postId} />
+      <CommentSection postId={postId} onCommentsChanged={loadPost} />
     </main>
   )
 }

--- a/frontend/components/comment/CommentSection.tsx
+++ b/frontend/components/comment/CommentSection.tsx
@@ -5,6 +5,7 @@ import { getAccessToken } from "@/lib/auth-storage"
 
 type CommentSectionProps = {
   postId: number
+  onCommentsChanged?: () => void | Promise<void>
 }
 
 type LoginRequiredPopupState = {
@@ -343,7 +344,7 @@ function sortCommentsByNewest(comments: CommentItem[]): CommentItem[] {
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
 }
 
-export default function CommentSection({ postId }: CommentSectionProps) {
+export default function CommentSection({ postId, onCommentsChanged }: CommentSectionProps) {
   const [comments, setComments] = useState<CommentItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -533,6 +534,7 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       setNewComment("")
       setNewCommentFiles([])
       await loadComments()
+      await onCommentsChanged?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
     } finally {
@@ -591,6 +593,7 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       }))
       setOpenedReplyId(null)
       await loadComments()
+      await onCommentsChanged?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
     } finally {
@@ -688,6 +691,7 @@ export default function CommentSection({ postId }: CommentSectionProps) {
       }
 
       await loadComments()
+      await onCommentsChanged?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.")
     } finally {


### PR DESCRIPTION
## 📌 관련 이슈

Closes #225 

## 🛠️ 작업 내용
- 댓글/대댓글 작성 시 게시글 `commentCount` 증가 반영

- 댓글 삭제 시 게시글 `commentCount` 감소 반영

- `PostService`에 `decreaseCommentCount()` 추가

- `CommentSection`에 `onCommentsChanged` 콜백 추가

- 게시글 상세 페이지에서 댓글 변경 후 게시글 상세 재조회 연결

- 메인 페이지에서 focus / visibilitychange 시 게시글 목록 재조회

- `CommentService`에 댓글 작성/대댓글 작성/수정/삭제/목록 조회 관련 로그 추가

- 로그 설정을 애플리케이션 INFO 로그 중심으로 조정

## 🎯 리뷰 포인트
- 댓글/대댓글 작성 및 삭제 후 메인/상세 화면의 댓글 수가 정상 반영되는지

- 상세 페이지에서 댓글 변경 후 `loadPost()`가 정상적으로 다시 호출되는지

- 메인 페이지 재진입/포커스 시 게시글 목록이 최신 데이터로 갱신되는지

- `CommentService` 로그가 주요 흐름과 실패 원인을 충분히 보여주는지

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="924" height="179" alt="image" src="https://github.com/user-attachments/assets/c39e2085-85d5-4d62-aa20-08c7da834f36" />
<img width="823" height="146" alt="image" src="https://github.com/user-attachments/assets/e7b05500-f445-4fc5-aee5-f5a0ca1f76ad" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?